### PR TITLE
Swift playground for iOS

### DIFF
--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		DA20FB9F1CE3DEBB00B07762 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA20FBA91CE401E800B07762 /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		DA20FBAB1CE4026B00B07762 /* Overlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Overlay.swift; sourceTree = "<group>"; };
+		DA20FBB21CE4682200B07762 /* iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = iOS.playground; sourceTree = "<group>"; };
 		DD0C88161BE1A9D400606E9F /* polyline.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = polyline.geojson; sourceTree = "<group>"; };
 		DDAD19591BD9B1780057AC9F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -141,6 +142,7 @@
 		DDAD19501BD9B1780057AC9F = {
 			isa = PBXGroup;
 			children = (
+				DA20FBB21CE4682200B07762 /* iOS.playground */,
 				DDAD195B1BD9B1780057AC9F /* Example */,
 				DA20FB9C1CE3DEBB00B07762 /* MapboxStatic */,
 				DDAD19791BD9B24F0057AC9F /* MapboxStaticTests */,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 MapboxStatic.swift makes it easy to connect your iOS, tvOS, or watchOS application to the [classic Mapbox Static API](https://www.mapbox.com/api-documentation/#static-classic). Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
 
-Static maps are flattened PNG or JPG images, ideal for use in table views, image views, and anyplace else you'd like a quick, custom map without the overhead of an interactive view. They are created in one HTTP request, so overlays are all added *server-side*. 
+Static maps are flattened PNG or JPG images, ideal for use in table views, image views, and anyplace else you'd like a quick, custom map without the overhead of an interactive view. They are created in one HTTP request, so overlays are all added *server-side*.
 
 MapboxStatic.swift pairs well with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift), [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), and the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [OS X SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/osx).
 
@@ -30,14 +30,14 @@ import MapboxStatic
 let options = SnapshotOptions(
     mapIdentifier: "<#your map ID#>",
     centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
-    zoomLevel: 6,
+    zoomLevel: 13,
     size: CGSize(width: 200, height: 200))
 let snapshot = Snapshot(
     options: options,
     accessToken: "<#your access token#>")
 ```
 
-Then, you can either retrieve an image synchronously (blocking the calling thread): 
+Then, you can either retrieve an image synchronously (blocking the calling thread):
 
 ```swift
 imageView.image = snapshot.image
@@ -45,7 +45,7 @@ imageView.image = snapshot.image
 
 ![](./screenshots/map.png)
 
-Or you can pass a completion handler to update the UI thread after the image is retrieved: 
+Or you can pass a completion handler to update the UI thread after the image is retrieved:
 
 ```swift
 snapshot.image { (image, error) in
@@ -53,7 +53,7 @@ snapshot.image { (image, error) in
 }
 ```
 
-If you're using your own HTTP library or routines, you can also retrieve a snapshot’s `requestURL` property. 
+If you're using your own HTTP library or routines, you can also retrieve a snapshot’s `requestURL` property.
 
 ```swift
 let requestURLToFetch = snapshot.requestURL
@@ -78,12 +78,12 @@ let markerOverlay = Marker(
 
 ![](./screenshots/marker.png)
 
-#### Custom Marker
+#### Custom marker
 
 ```swift
 let customMarker = CustomMarker(
     coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
-    URL: NSURL(string: "https://mapbox.com/guides/img/rocket.png")!
+    URL: NSURL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!
 )
 ```
 
@@ -140,7 +140,7 @@ let path = Path(
 
 #### Auto-fitting features
 
-If you’re adding overlays to your map, leave out the center coordinate and zoom level to automatically calculate the center and zoom level that best shows them off. 
+If you’re adding overlays to your map, leave out the center coordinate and zoom level to automatically calculate the center and zoom level that best shows them off.
 
 ```swift
 var options = SnapshotOptions(
@@ -151,13 +151,13 @@ options.overlays = [path, geojsonOverlay, markerOverlay, customMarker]
 
 ![](screenshots/autofit.png)
 
-#### File format & quality
+#### File format and quality
 
 When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).
 
 #### Attribution
 
-Be sure to [attribute your map](https://www.mapbox.com/api-documentation/#static-classic) properly in your app. You can also [find out more](https://www.mapbox.com/about/maps/) about where Mapbox's map data comes from. 
+Be sure to [attribute your map](https://www.mapbox.com/api-documentation/#static-classic) properly in your app. You can also [find out more](https://www.mapbox.com/about/maps/) about where Mapbox's map data comes from.
 
 ### Tests
 

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -1,0 +1,157 @@
+import CoreLocation
+import UIKit
+import MapboxStatic
+
+/*:
+ # MapboxStatic.swift
+ 
+ MapboxStatic.swift makes it easy to connect your iOS application to the [classic Mapbox Static API](https://www.mapbox.com/api-documentation/#static-classic). Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
+ 
+ Static maps are flattened PNG or JPG images, ideal for use in table views, image views, and anyplace else you’d like a quick, custom map without the overhead of an interactive view. They are created in one HTTP request, so overlays are all added *server-side*.
+ 
+ ## Usage
+ 
+ You will need a [map ID](https://www.mapbox.com/foundations/glossary/#mapid) from a [custom map style](https://www.mapbox.com/foundations/customizing-the-map) on your Mapbox account. You will also need an [access token](https://www.mapbox.com/developers/api/#access-tokens) in order to use the API.
+ 
+ You can specify your access token inline or by setting the `MGLMapboxAccessToken` key in your application’s Info.plist file.
+ */
+
+let mapIdentifier = "justin.tm2-basemap"
+let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
+
+/*:
+ ## Basics
+ 
+ The main static map class is `Snapshot`. To create a basic snapshot, create a `SnapshotOptions` object, specifying the center coordinates, [zoom level](https://www.mapbox.com/guides/how-web-maps-work/#tiles-and-zoom-levels), and point size:
+ */
+
+var options = SnapshotOptions(
+    mapIdentifier: mapIdentifier,
+    centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
+    zoomLevel: 13,
+    size: CGSize(width: 300, height: 200))
+var snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+
+/*:
+ Then, you can either retrieve an image synchronously (blocking the calling thread):
+ */
+snapshot.image
+
+/*:
+ Or you can pass a completion handler to update the UI thread after the image is retrieved:
+ */
+let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+snapshot.image { (image, error) in
+    imageView.image = image
+}
+
+/*:
+ If you’re using your own HTTP library or routines, you can also retrieve a snapshot’s `requestURL` property.
+ */
+snapshot.requestURL
+
+/*:
+ ## Overlays
+ 
+ Overlays are where things get interesting! You can add [Maki markers](https://www.mapbox.com/maki/), custom marker imagery, GeoJSON geometries, and even paths made of bare coordinates.
+ 
+ You add overlays to the `overlays` field in the `SnapshotOptions` object. Here are some versions of our snapshot with various overlays added.
+ 
+ ### Marker
+ */
+let markerOverlay = Marker(
+    coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
+    size: .Medium,
+    label: "cafe",
+    color: .brownColor())
+options.overlays = [markerOverlay]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### Custom marker
+ */
+let customMarker = CustomMarker(
+    coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
+    URL: NSURL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!)
+options.overlays = [customMarker]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### GeoJSON
+ */
+let geojsonOverlay: GeoJSON
+do {
+    let geojsonURL = NSURL(string: "http://git.io/vCv9U")!
+    let geojsonString = try NSString(contentsOfURL: geojsonURL, encoding: NSUTF8StringEncoding)
+    geojsonOverlay = GeoJSON(string: geojsonString as String)
+}
+options.overlays = [geojsonOverlay]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### Path
+ */
+let path = Path(
+    pathCoordinates: [
+        CLLocationCoordinate2D(
+            latitude: 45.52475063103141,
+            longitude: -122.68209457397461),
+        CLLocationCoordinate2D(
+            latitude: 45.52451009822193,
+            longitude: -122.67488479614258),
+        CLLocationCoordinate2D(
+            latitude: 45.51681250530043,
+            longitude: -122.67608642578126),
+        CLLocationCoordinate2D(
+            latitude: 45.51693278828882,
+            longitude: -122.68999099731445),
+        CLLocationCoordinate2D(
+            latitude: 45.520300607576864,
+            longitude: -122.68964767456055),
+        CLLocationCoordinate2D(
+            latitude: 45.52475063103141,
+            longitude: -122.68209457397461),
+    ],
+    strokeWidth: 2,
+    strokeColor: .blackColor(),
+    fillColor: .redColor(),
+    fillOpacity: 0.25)
+options.overlays = [path]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ## Other options
+ 
+ ### Auto-fitting features
+ 
+ If you’re adding overlays to your map, leave out the center coordinate and zoom level to automatically calculate the center and zoom level that best shows them off.
+ */
+options.overlays = [path, geojsonOverlay, markerOverlay, customMarker]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### File format and quality
+ 
+ When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).
+ 
+ ### Attribution
+ 
+ Be sure to [attribute your map](https://www.mapbox.com/api-documentation/#static-classic) properly in your app. You can also [find out more](https://www.mapbox.com/about/maps/) about where Mapbox’s map data comes from.
+ */

--- a/iOS.playground/contents.xcplayground
+++ b/iOS.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' display-mode='raw'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/iOS.playground/contents.xcplayground
+++ b/iOS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='raw'>
+<playground version='5.0' target-platform='ios' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/timeline.xctimeline
+++ b/iOS.playground/timeline.xctimeline
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1846&amp;EndingColumnNumber=15&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2896&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3240&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3638&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4630&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5013&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=484733350.240847"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+   </TimelineItems>
+</Timeline>


### PR DESCRIPTION
Added a Swift playground for iOS that regurgitates the examples in the readme, except with live results. Also updated the URL to the rocket image used for the custom marker example.

/cc @boundsj @tmcw