### PR TITLE
Support OS X

### DIFF
--- a/MapboxStatic.swift.podspec
+++ b/MapboxStatic.swift.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.summary      = "Classic Mapbox Static API wrapper for Objective-C and Swift."
 
   s.description  = <<-DESC
-  MapboxStatic.swift makes it easy to connect your iOS, tvOS, or watchOS application to the classic Mapbox Static API. Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
+  MapboxStatic.swift makes it easy to connect your iOS, OS X, tvOS, or watchOS application to the classic Mapbox Static API. Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
                    DESC
 
   s.homepage     = "https://www.mapbox.com/api-documentation/#static-classic"
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   #  When using multiple platforms
   s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
 

--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -1,597 +1,1797 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		DA20FB9E1CE3DEBB00B07762 /* MapboxStatic.h in Headers */ = {isa = PBXBuildFile; fileRef = DA20FB9D1CE3DEBB00B07762 /* MapboxStatic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA20FBA21CE3DEBB00B07762 /* MapboxStatic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */; };
-		DA20FBA31CE3DEBB00B07762 /* MapboxStatic.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DA20FBA81CE3DF6900B07762 /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD19871BD9B3970057AC9F /* Snapshot.swift */; };
-		DA20FBAA1CE401E800B07762 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20FBA91CE401E800B07762 /* UIColor.swift */; };
-		DA20FBAC1CE4026B00B07762 /* Overlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20FBAB1CE4026B00B07762 /* Overlay.swift */; };
-		DD0C88181BE1A9E100606E9F /* polyline.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DD0C88161BE1A9D400606E9F /* polyline.geojson */; };
-		DD685BA91BDB14C1002E2BB2 /* MapboxStaticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD19831BD9B2F80057AC9F /* MapboxStaticTests.swift */; };
-		DDAD19711BD9B1A50057AC9F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */; };
-		DDAD19731BD9B1A50057AC9F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD19701BD9B1A50057AC9F /* ViewController.swift */; };
-		E1BB8C3C8B4B34ABA4521545 /* Pods_MapboxStaticTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBD735B8583D022CA2165EFB /* Pods_MapboxStaticTests.framework */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		DA20FBA01CE3DEBB00B07762 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DDAD19511BD9B1780057AC9F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DA20FB9A1CE3DEBB00B07762;
-			remoteInfo = MapboxStatic;
-		};
-		DDAD197D1BD9B24F0057AC9F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DDAD19511BD9B1780057AC9F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DDAD19581BD9B1780057AC9F;
-			remoteInfo = "Sample App";
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		DA20FBA71CE3DEBB00B07762 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				DA20FBA31CE3DEBB00B07762 /* MapboxStatic.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
-/* Begin PBXFileReference section */
-		20757D6C38E229374CC0488B /* Pods_MapboxStatic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxStatic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8D6EE47FD26DFA5AB2812FB2 /* Pods-MapboxStaticTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxStaticTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests.debug.xcconfig"; sourceTree = "<group>"; };
-		BA5C146F8A26FA67089F5234 /* Pods-MapboxStaticTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxStaticTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests.release.xcconfig"; sourceTree = "<group>"; };
-		BBD735B8583D022CA2165EFB /* Pods_MapboxStaticTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxStaticTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxStatic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA20FB9D1CE3DEBB00B07762 /* MapboxStatic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapboxStatic.h; sourceTree = "<group>"; };
-		DA20FB9F1CE3DEBB00B07762 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DA20FBA91CE401E800B07762 /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
-		DA20FBAB1CE4026B00B07762 /* Overlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Overlay.swift; sourceTree = "<group>"; };
-		DA20FBB21CE4682200B07762 /* iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = iOS.playground; sourceTree = "<group>"; };
-		DD0C88161BE1A9D400606E9F /* polyline.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = polyline.geojson; sourceTree = "<group>"; };
-		DDAD19591BD9B1780057AC9F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		DDAD196F1BD9B1A50057AC9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DDAD19701BD9B1A50057AC9F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		DDAD19781BD9B24F0057AC9F /* MapboxStaticTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxStaticTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DDAD19831BD9B2F80057AC9F /* MapboxStaticTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapboxStaticTests.swift; sourceTree = "<group>"; };
-		DDAD19841BD9B2F80057AC9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DDAD19871BD9B3970057AC9F /* Snapshot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Snapshot.swift; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		DA20FB971CE3DEBB00B07762 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19561BD9B1780057AC9F /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DA20FBA21CE3DEBB00B07762 /* MapboxStatic.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19751BD9B24F0057AC9F /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E1BB8C3C8B4B34ABA4521545 /* Pods_MapboxStaticTests.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		84F6A9708C9492676B182C3A /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BBD735B8583D022CA2165EFB /* Pods_MapboxStaticTests.framework */,
-				20757D6C38E229374CC0488B /* Pods_MapboxStatic.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		B4D1009D4B831C7BA3D1ED4A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				8D6EE47FD26DFA5AB2812FB2 /* Pods-MapboxStaticTests.debug.xcconfig */,
-				BA5C146F8A26FA67089F5234 /* Pods-MapboxStaticTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		DA20FB9C1CE3DEBB00B07762 /* MapboxStatic */ = {
-			isa = PBXGroup;
-			children = (
-				DA20FB9D1CE3DEBB00B07762 /* MapboxStatic.h */,
-				DDAD19871BD9B3970057AC9F /* Snapshot.swift */,
-				DA20FBAB1CE4026B00B07762 /* Overlay.swift */,
-				DA20FBA91CE401E800B07762 /* UIColor.swift */,
-				DA20FB9F1CE3DEBB00B07762 /* Info.plist */,
-			);
-			path = MapboxStatic;
-			sourceTree = "<group>";
-		};
-		DD0C88151BE1A9CC00606E9F /* Fixtures */ = {
-			isa = PBXGroup;
-			children = (
-				DD0C88161BE1A9D400606E9F /* polyline.geojson */,
-			);
-			name = Fixtures;
-			path = fixtures;
-			sourceTree = "<group>";
-		};
-		DDAD19501BD9B1780057AC9F = {
-			isa = PBXGroup;
-			children = (
-				DA20FBB21CE4682200B07762 /* iOS.playground */,
-				DDAD195B1BD9B1780057AC9F /* Example */,
-				DA20FB9C1CE3DEBB00B07762 /* MapboxStatic */,
-				DDAD19791BD9B24F0057AC9F /* MapboxStaticTests */,
-				DDAD195A1BD9B1780057AC9F /* Products */,
-				B4D1009D4B831C7BA3D1ED4A /* Pods */,
-				84F6A9708C9492676B182C3A /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		DDAD195A1BD9B1780057AC9F /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DDAD19591BD9B1780057AC9F /* Example.app */,
-				DDAD19781BD9B24F0057AC9F /* MapboxStaticTests.xctest */,
-				DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DDAD195B1BD9B1780057AC9F /* Example */ = {
-			isa = PBXGroup;
-			children = (
-				DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */,
-				DDAD19701BD9B1A50057AC9F /* ViewController.swift */,
-				DDAD196F1BD9B1A50057AC9F /* Info.plist */,
-			);
-			path = Example;
-			sourceTree = "<group>";
-		};
-		DDAD19791BD9B24F0057AC9F /* MapboxStaticTests */ = {
-			isa = PBXGroup;
-			children = (
-				DDAD19831BD9B2F80057AC9F /* MapboxStaticTests.swift */,
-				DDAD19841BD9B2F80057AC9F /* Info.plist */,
-				DD0C88151BE1A9CC00606E9F /* Fixtures */,
-			);
-			path = MapboxStaticTests;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		DA20FB981CE3DEBB00B07762 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DA20FB9E1CE3DEBB00B07762 /* MapboxStatic.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		DA20FB9A1CE3DEBB00B07762 /* MapboxStatic */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DA20FBA41CE3DEBB00B07762 /* Build configuration list for PBXNativeTarget "MapboxStatic" */;
-			buildPhases = (
-				DA20FB961CE3DEBB00B07762 /* Sources */,
-				DA20FB971CE3DEBB00B07762 /* Frameworks */,
-				DA20FB981CE3DEBB00B07762 /* Headers */,
-				DA20FB991CE3DEBB00B07762 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = MapboxStatic;
-			productName = MapboxStatic;
-			productReference = DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		DDAD19581BD9B1780057AC9F /* Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example" */;
-			buildPhases = (
-				DDAD19551BD9B1780057AC9F /* Sources */,
-				DDAD19561BD9B1780057AC9F /* Frameworks */,
-				DDAD19571BD9B1780057AC9F /* Resources */,
-				DA20FBA71CE3DEBB00B07762 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DA20FBA11CE3DEBB00B07762 /* PBXTargetDependency */,
-			);
-			name = Example;
-			productName = "Sample App";
-			productReference = DDAD19591BD9B1780057AC9F /* Example.app */;
-			productType = "com.apple.product-type.application";
-		};
-		DDAD19771BD9B24F0057AC9F /* MapboxStaticTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DDAD197F1BD9B24F0057AC9F /* Build configuration list for PBXNativeTarget "MapboxStaticTests" */;
-			buildPhases = (
-				DDAD19741BD9B24F0057AC9F /* Sources */,
-				DDAD19751BD9B24F0057AC9F /* Frameworks */,
-				DDAD19761BD9B24F0057AC9F /* Resources */,
-				70E811F2996100A2FA178EF4 /* Embed Pods Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DDAD197E1BD9B24F0057AC9F /* PBXTargetDependency */,
-			);
-			name = MapboxStaticTests;
-			productName = "Unit Tests";
-			productReference = DDAD19781BD9B24F0057AC9F /* MapboxStaticTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		DDAD19511BD9B1780057AC9F /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0710;
-				ORGANIZATIONNAME = Mapbox;
-				TargetAttributes = {
-					DA20FB9A1CE3DEBB00B07762 = {
-						CreatedOnToolsVersion = 7.3.1;
-					};
-					DDAD19581BD9B1780057AC9F = {
-						CreatedOnToolsVersion = 7.1;
-					};
-					DDAD19771BD9B24F0057AC9F = {
-						CreatedOnToolsVersion = 7.1;
-					};
-				};
-			};
-			buildConfigurationList = DDAD19541BD9B1780057AC9F /* Build configuration list for PBXProject "MapboxStatic" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = DDAD19501BD9B1780057AC9F;
-			productRefGroup = DDAD195A1BD9B1780057AC9F /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				DDAD19581BD9B1780057AC9F /* Example */,
-				DA20FB9A1CE3DEBB00B07762 /* MapboxStatic */,
-				DDAD19771BD9B24F0057AC9F /* MapboxStaticTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		DA20FB991CE3DEBB00B07762 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19571BD9B1780057AC9F /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19761BD9B24F0057AC9F /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD0C88181BE1A9E100606E9F /* polyline.geojson in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		70E811F2996100A2FA178EF4 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		DA20FB961CE3DEBB00B07762 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DA20FBA81CE3DF6900B07762 /* Snapshot.swift in Sources */,
-				DA20FBAC1CE4026B00B07762 /* Overlay.swift in Sources */,
-				DA20FBAA1CE401E800B07762 /* UIColor.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19551BD9B1780057AC9F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DDAD19711BD9B1A50057AC9F /* AppDelegate.swift in Sources */,
-				DDAD19731BD9B1A50057AC9F /* ViewController.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DDAD19741BD9B24F0057AC9F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD685BA91BDB14C1002E2BB2 /* MapboxStaticTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		DA20FBA11CE3DEBB00B07762 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DA20FB9A1CE3DEBB00B07762 /* MapboxStatic */;
-			targetProxy = DA20FBA01CE3DEBB00B07762 /* PBXContainerItemProxy */;
-		};
-		DDAD197E1BD9B24F0057AC9F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DDAD19581BD9B1780057AC9F /* Example */;
-			targetProxy = DDAD197D1BD9B24F0057AC9F /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		DA20FBA51CE3DEBB00B07762 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = MapboxStatic/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		DA20FBA61CE3DEBB00B07762 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = MapboxStatic/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		DDAD19691BD9B1780057AC9F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		DDAD196A1BD9B1780057AC9F /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		DDAD196C1BD9B1780057AC9F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		DDAD196D1BD9B1780057AC9F /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		DDAD19801BD9B24F0057AC9F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8D6EE47FD26DFA5AB2812FB2 /* Pods-MapboxStaticTests.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				INFOPLIST_FILE = MapboxStaticTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Debug;
-		};
-		DDAD19811BD9B24F0057AC9F /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = BA5C146F8A26FA67089F5234 /* Pods-MapboxStaticTests.release.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				INFOPLIST_FILE = MapboxStaticTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		DA20FBA41CE3DEBB00B07762 /* Build configuration list for PBXNativeTarget "MapboxStatic" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DA20FBA51CE3DEBB00B07762 /* Debug */,
-				DA20FBA61CE3DEBB00B07762 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		DDAD19541BD9B1780057AC9F /* Build configuration list for PBXProject "MapboxStatic" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DDAD19691BD9B1780057AC9F /* Debug */,
-				DDAD196A1BD9B1780057AC9F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DDAD196C1BD9B1780057AC9F /* Debug */,
-				DDAD196D1BD9B1780057AC9F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		DDAD197F1BD9B24F0057AC9F /* Build configuration list for PBXNativeTarget "MapboxStaticTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DDAD19801BD9B24F0057AC9F /* Debug */,
-				DDAD19811BD9B24F0057AC9F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = DDAD19511BD9B1780057AC9F /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>0ED9A3D399DBFF0D29EB538D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7D3DEA5BAEBEE5A5E2D5A451</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>20757D6C38E229374CC0488B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods_MapboxStatic.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>28CC27E80B7FF2D37662BE6B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-MapboxStaticMacTests.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>54F68F1C4290CF8B973B22E9</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>70E811F2996100A2FA178EF4</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Embed Pods Frameworks</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests-frameworks.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>7D3DEA5BAEBEE5A5E2D5A451</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods_MapboxStaticMacTests.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>84F6A9708C9492676B182C3A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BBD735B8583D022CA2165EFB</string>
+				<string>20757D6C38E229374CC0488B</string>
+				<string>7D3DEA5BAEBEE5A5E2D5A451</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8D6EE47FD26DFA5AB2812FB2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-MapboxStaticTests.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B4D1009D4B831C7BA3D1ED4A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>8D6EE47FD26DFA5AB2812FB2</string>
+				<string>BA5C146F8A26FA67089F5234</string>
+				<string>28CC27E80B7FF2D37662BE6B</string>
+				<string>CFF167EC71AC2058F825CEB9</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BA5C146F8A26FA67089F5234</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-MapboxStaticTests.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BBD735B8583D022CA2165EFB</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods_MapboxStaticTests.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>CFF167EC71AC2058F825CEB9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-MapboxStaticMacTests.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FB961CE3DEBB00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBA81CE3DF6900B07762</string>
+				<string>DA20FBAC1CE4026B00B07762</string>
+				<string>DA20FBAA1CE401E800B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FB971CE3DEBB00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FB981CE3DEBB00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FB9E1CE3DEBB00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FB991CE3DEBB00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FB9A1CE3DEBB00B07762</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DA20FBA41CE3DEBB00B07762</string>
+			<key>buildPhases</key>
+			<array>
+				<string>DA20FB961CE3DEBB00B07762</string>
+				<string>DA20FB971CE3DEBB00B07762</string>
+				<string>DA20FB981CE3DEBB00B07762</string>
+				<string>DA20FB991CE3DEBB00B07762</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>MapboxStatic</string>
+			<key>productName</key>
+			<string>MapboxStatic</string>
+			<key>productReference</key>
+			<string>DA20FB9B1CE3DEBB00B07762</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>DA20FB9B1CE3DEBB00B07762</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>MapboxStatic.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DA20FB9C1CE3DEBB00B07762</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DA20FB9D1CE3DEBB00B07762</string>
+				<string>DDAD19871BD9B3970057AC9F</string>
+				<string>DA20FBAB1CE4026B00B07762</string>
+				<string>DA20FBA91CE401E800B07762</string>
+				<string>DA20FB9F1CE3DEBB00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>MapboxStatic</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FB9D1CE3DEBB00B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>MapboxStatic.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FB9E1CE3DEBB00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FB9D1CE3DEBB00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DA20FB9F1CE3DEBB00B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FBA01CE3DEBB00B07762</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>DDAD19511BD9B1780057AC9F</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>DA20FB9A1CE3DEBB00B07762</string>
+			<key>remoteInfo</key>
+			<string>MapboxStatic</string>
+		</dict>
+		<key>DA20FBA11CE3DEBB00B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>DA20FB9A1CE3DEBB00B07762</string>
+			<key>targetProxy</key>
+			<string>DA20FBA01CE3DEBB00B07762</string>
+		</dict>
+		<key>DA20FBA21CE3DEBB00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FB9B1CE3DEBB00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBA31CE3DEBB00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FB9B1CE3DEBB00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>CodeSignOnCopy</string>
+					<string>RemoveHeadersOnCopy</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DA20FBA41CE3DEBB00B07762</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DA20FBA51CE3DEBB00B07762</string>
+				<string>DA20FBA61CE3DEBB00B07762</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DA20FBA51CE3DEBB00B07762</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStatic/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStatic</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DA20FBA61CE3DEBB00B07762</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStatic/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStatic</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DA20FBA71CE3DEBB00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>dstPath</key>
+			<string></string>
+			<key>dstSubfolderSpec</key>
+			<string>10</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBA31CE3DEBB00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXCopyFilesBuildPhase</string>
+			<key>name</key>
+			<string>Embed Frameworks</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBA81CE3DF6900B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD19871BD9B3970057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBA91CE401E800B07762</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Color.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FBAA1CE401E800B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FBA91CE401E800B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBAB1CE4026B00B07762</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Overlay.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FBAC1CE4026B00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FBAB1CE4026B00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBB21CE4682200B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>file.playground</string>
+			<key>path</key>
+			<string>iOS.playground</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FBB31CE474CA00B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>file.playground</string>
+			<key>path</key>
+			<string>OS X.playground</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA20FBB41CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBD21CE475F300B07762</string>
+				<string>DA20FBD31CE475F300B07762</string>
+				<string>DA20FBD11CE475F300B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBB51CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBB61CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBD01CE475F300B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBB71CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBB81CE4757E00B07762</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DA20FBCA1CE4757E00B07762</string>
+			<key>buildPhases</key>
+			<array>
+				<string>DA20FBB41CE4757E00B07762</string>
+				<string>DA20FBB51CE4757E00B07762</string>
+				<string>DA20FBB61CE4757E00B07762</string>
+				<string>DA20FBB71CE4757E00B07762</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>MapboxStaticMac</string>
+			<key>productName</key>
+			<string>MapboxStaticMac</string>
+			<key>productReference</key>
+			<string>DA20FBB91CE4757E00B07762</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>DA20FBB91CE4757E00B07762</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>MapboxStatic.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DA20FBBE1CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBD41CE475FD00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBBF1CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBC31CE4757E00B07762</string>
+				<string>0ED9A3D399DBFF0D29EB538D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBC01CE4757E00B07762</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBD51CE4760100B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DA20FBC11CE4757E00B07762</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DA20FBCD1CE4757E00B07762</string>
+			<key>buildPhases</key>
+			<array>
+				<string>E8C559A359056DF4F82323F6</string>
+				<string>DA20FBBE1CE4757E00B07762</string>
+				<string>DA20FBBF1CE4757E00B07762</string>
+				<string>DA20FBC01CE4757E00B07762</string>
+				<string>EA5F774C741A7A6A42F261A5</string>
+				<string>54F68F1C4290CF8B973B22E9</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>DA20FBC51CE4757E00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>MapboxStaticMacTests</string>
+			<key>productName</key>
+			<string>MapboxStaticMacTests</string>
+			<key>productReference</key>
+			<string>DA20FBC21CE4757E00B07762</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>DA20FBC21CE4757E00B07762</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>MapboxStaticTests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DA20FBC31CE4757E00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FBB91CE4757E00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBC41CE4757E00B07762</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>DDAD19511BD9B1780057AC9F</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>DA20FBB81CE4757E00B07762</string>
+			<key>remoteInfo</key>
+			<string>MapboxStaticMac</string>
+		</dict>
+		<key>DA20FBC51CE4757E00B07762</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>DA20FBB81CE4757E00B07762</string>
+			<key>targetProxy</key>
+			<string>DA20FBC41CE4757E00B07762</string>
+		</dict>
+		<key>DA20FBCA1CE4757E00B07762</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DA20FBCB1CE4757E00B07762</string>
+				<string>DA20FBCC1CE4757E00B07762</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DA20FBCB1CE4757E00B07762</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>-</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStatic/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/../Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStatic</string>
+				<key>PRODUCT_NAME</key>
+				<string>MapboxStatic</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DA20FBCC1CE4757E00B07762</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>-</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStatic/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/../Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStatic</string>
+				<key>PRODUCT_NAME</key>
+				<string>MapboxStatic</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DA20FBCD1CE4757E00B07762</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DA20FBCE1CE4757E00B07762</string>
+				<string>DA20FBCF1CE4757E00B07762</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DA20FBCE1CE4757E00B07762</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>28CC27E80B7FF2D37662BE6B</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>-</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStaticTests/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStaticTests</string>
+				<key>PRODUCT_NAME</key>
+				<string>MapboxStaticTests</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DA20FBCF1CE4757E00B07762</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>CFF167EC71AC2058F825CEB9</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ANALYZER_NONNULL</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>-</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStaticTests/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.MapboxStaticTests</string>
+				<key>PRODUCT_NAME</key>
+				<string>MapboxStaticTests</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DA20FBD01CE475F300B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FB9D1CE3DEBB00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DA20FBD11CE475F300B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD19871BD9B3970057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBD21CE475F300B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FBAB1CE4026B00B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBD31CE475F300B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DA20FBA91CE401E800B07762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBD41CE475FD00B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD19831BD9B2F80057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DA20FBD51CE4760100B07762</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DD0C88161BE1A9D400606E9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DD0C88151BE1A9CC00606E9F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DD0C88161BE1A9D400606E9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Fixtures</string>
+			<key>path</key>
+			<string>fixtures</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DD0C88161BE1A9D400606E9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>polyline.geojson</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DD0C88181BE1A9E100606E9F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DD0C88161BE1A9D400606E9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DD685BA91BDB14C1002E2BB2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD19831BD9B2F80057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DDAD19501BD9B1780057AC9F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DA20FBB21CE4682200B07762</string>
+				<string>DA20FBB31CE474CA00B07762</string>
+				<string>DDAD195B1BD9B1780057AC9F</string>
+				<string>DA20FB9C1CE3DEBB00B07762</string>
+				<string>DDAD19791BD9B24F0057AC9F</string>
+				<string>DDAD195A1BD9B1780057AC9F</string>
+				<string>B4D1009D4B831C7BA3D1ED4A</string>
+				<string>84F6A9708C9492676B182C3A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19511BD9B1780057AC9F</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0730</string>
+				<key>LastUpgradeCheck</key>
+				<string>0710</string>
+				<key>ORGANIZATIONNAME</key>
+				<string>Mapbox</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>DA20FB9A1CE3DEBB00B07762</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.3.1</string>
+					</dict>
+					<key>DA20FBB81CE4757E00B07762</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.3.1</string>
+					</dict>
+					<key>DA20FBC11CE4757E00B07762</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.3.1</string>
+					</dict>
+					<key>DDAD19581BD9B1780057AC9F</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.1</string>
+					</dict>
+					<key>DDAD19771BD9B24F0057AC9F</key>
+					<dict>
+						<key>CreatedOnToolsVersion</key>
+						<string>7.1</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>DDAD19541BD9B1780057AC9F</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+				<string>Base</string>
+			</array>
+			<key>mainGroup</key>
+			<string>DDAD19501BD9B1780057AC9F</string>
+			<key>productRefGroup</key>
+			<string>DDAD195A1BD9B1780057AC9F</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>DDAD19581BD9B1780057AC9F</string>
+				<string>DA20FB9A1CE3DEBB00B07762</string>
+				<string>DDAD19771BD9B24F0057AC9F</string>
+				<string>DA20FBB81CE4757E00B07762</string>
+				<string>DA20FBC11CE4757E00B07762</string>
+			</array>
+		</dict>
+		<key>DDAD19541BD9B1780057AC9F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DDAD19691BD9B1780057AC9F</string>
+				<string>DDAD196A1BD9B1780057AC9F</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DDAD19551BD9B1780057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DDAD19711BD9B1A50057AC9F</string>
+				<string>DDAD19731BD9B1A50057AC9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19561BD9B1780057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DA20FBA21CE3DEBB00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19571BD9B1780057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19581BD9B1780057AC9F</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DDAD196B1BD9B1780057AC9F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>DDAD19551BD9B1780057AC9F</string>
+				<string>DDAD19561BD9B1780057AC9F</string>
+				<string>DDAD19571BD9B1780057AC9F</string>
+				<string>DA20FBA71CE3DEBB00B07762</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>DA20FBA11CE3DEBB00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Example</string>
+			<key>productName</key>
+			<string>Sample App</string>
+			<key>productReference</key>
+			<string>DDAD19591BD9B1780057AC9F</string>
+			<key>productType</key>
+			<string>com.apple.product-type.application</string>
+		</dict>
+		<key>DDAD19591BD9B1780057AC9F</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.application</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Example.app</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DDAD195A1BD9B1780057AC9F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DDAD19591BD9B1780057AC9F</string>
+				<string>DDAD19781BD9B24F0057AC9F</string>
+				<string>DA20FB9B1CE3DEBB00B07762</string>
+				<string>DA20FBB91CE4757E00B07762</string>
+				<string>DA20FBC21CE4757E00B07762</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD195B1BD9B1780057AC9F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DDAD196E1BD9B1A50057AC9F</string>
+				<string>DDAD19701BD9B1A50057AC9F</string>
+				<string>DDAD196F1BD9B1A50057AC9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Example</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19691BD9B1780057AC9F</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>ENABLE_TESTABILITY</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.10</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DDAD196A1BD9B1780057AC9F</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_NO_COMMON_BLOCKS</key>
+				<string>YES</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.10</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DDAD196B1BD9B1780057AC9F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DDAD196C1BD9B1780057AC9F</string>
+				<string>DDAD196D1BD9B1780057AC9F</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DDAD196C1BD9B1780057AC9F</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>EMBEDDED_CONTENT_CONTAINS_SWIFT</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>$(SRCROOT)/Example/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.StaticExample</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DDAD196D1BD9B1780057AC9F</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>EMBEDDED_CONTENT_CONTAINS_SWIFT</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>$(SRCROOT)/Example/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.StaticExample</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DDAD196E1BD9B1A50057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>AppDelegate.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD196F1BD9B1A50057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19701BD9B1A50057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>ViewController.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19711BD9B1A50057AC9F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD196E1BD9B1A50057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DDAD19731BD9B1A50057AC9F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DDAD19701BD9B1A50057AC9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DDAD19741BD9B24F0057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DD685BA91BDB14C1002E2BB2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19751BD9B24F0057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>E1BB8C3C8B4B34ABA4521545</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19761BD9B24F0057AC9F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DD0C88181BE1A9E100606E9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DDAD19771BD9B24F0057AC9F</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DDAD197F1BD9B24F0057AC9F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>DDAD19741BD9B24F0057AC9F</string>
+				<string>DDAD19751BD9B24F0057AC9F</string>
+				<string>DDAD19761BD9B24F0057AC9F</string>
+				<string>70E811F2996100A2FA178EF4</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>DDAD197E1BD9B24F0057AC9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>MapboxStaticTests</string>
+			<key>productName</key>
+			<string>Unit Tests</string>
+			<key>productReference</key>
+			<string>DDAD19781BD9B24F0057AC9F</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>DDAD19781BD9B24F0057AC9F</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>MapboxStaticTests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DDAD19791BD9B24F0057AC9F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>DDAD19831BD9B2F80057AC9F</string>
+				<string>DDAD19841BD9B2F80057AC9F</string>
+				<string>DD0C88151BE1A9CC00606E9F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>MapboxStaticTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD197D1BD9B24F0057AC9F</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>DDAD19511BD9B1780057AC9F</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>DDAD19581BD9B1780057AC9F</string>
+			<key>remoteInfo</key>
+			<string>Sample App</string>
+		</dict>
+		<key>DDAD197E1BD9B24F0057AC9F</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>DDAD19581BD9B1780057AC9F</string>
+			<key>targetProxy</key>
+			<string>DDAD197D1BD9B24F0057AC9F</string>
+		</dict>
+		<key>DDAD197F1BD9B24F0057AC9F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>DDAD19801BD9B24F0057AC9F</string>
+				<string>DDAD19811BD9B24F0057AC9F</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DDAD19801BD9B24F0057AC9F</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8D6EE47FD26DFA5AB2812FB2</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStaticTests/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.StaticTests</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>DDAD19811BD9B24F0057AC9F</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>BA5C146F8A26FA67089F5234</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>MapboxStaticTests/Info.plist</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<string>$(inherited) @executable_path/Frameworks @loader_path/Frameworks</string>
+				<key>PRODUCT_BUNDLE_IDENTIFIER</key>
+				<string>com.mapbox.StaticTests</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DDAD19831BD9B2F80057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>MapboxStaticTests.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19841BD9B2F80057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DDAD19871BD9B3970057AC9F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>path</key>
+			<string>Snapshot.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E1BB8C3C8B4B34ABA4521545</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BBD735B8583D022CA2165EFB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E8C559A359056DF4F82323F6</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>EA5F774C741A7A6A42F261A5</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Embed Pods Frameworks</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests-frameworks.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>DDAD19511BD9B1780057AC9F</string>
+</dict>
+</plist>

--- a/MapboxStatic/Color.swift
+++ b/MapboxStatic/Color.swift
@@ -1,15 +1,25 @@
-import UIKit
+#if os(iOS)
+    import UIKit
+    typealias Color = UIColor
+#elseif os(OSX)
+    import Cocoa
+    typealias Color = NSColor
+#endif
 
-internal extension UIColor {
-
+internal extension Color {
     internal func toHexString() -> String {
-
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0
         var a: CGFloat = 0
 
-        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let color: Color
+        #if os(iOS)
+            color = self
+        #elseif os(OSX)
+            color = colorUsingColorSpaceName(NSCalibratedRGBColorSpace)!
+        #endif
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
 
         r *= 255
         g *= 255
@@ -18,8 +28,7 @@ internal extension UIColor {
         return NSString(format: "%02x%02x%02x", Int(r), Int(g), Int(b)) as String
     }
 
-    internal class func colorWithHexString(hexString: String) -> UIColor {
-
+    convenience init(hexString: String) {
         var hexString = hexString.stringByReplacingOccurrencesOfString("#", withString: "")
 
         if hexString.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == 3 {
@@ -30,22 +39,24 @@ internal extension UIColor {
             hexString = r + r + g + g + b + b
         }
 
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        
         if hexString.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == 6 {
-            var r: CGFloat = 0
-            var g: CGFloat = 0
-            var b: CGFloat = 0
-
             var hexInt: UInt32 = 0
 
             if NSScanner(string: hexString).scanHexInt(&hexInt) {
                 r = CGFloat((hexInt >> 16) & 0xff) / 255
                 g = CGFloat((hexInt >> 8) & 0xff) / 255
                 b = CGFloat(hexInt & 0xff) / 255
-
-                return UIColor(red: r, green: g, blue: b, alpha: 1)
             }
         }
 
-        return UIColor.blackColor()
+        #if os(iOS)
+            self.init(red: r, green: g, blue: b, alpha: 1)
+        #elseif os(OSX)
+            self.init(calibratedRed: r, green: g, blue: b, alpha: 1)
+        #endif
     }
 }

--- a/MapboxStatic/MapboxStatic.h
+++ b/MapboxStatic/MapboxStatic.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <Foundation/Foundation.h>
 
 //! Project version number for MapboxStatic.
 FOUNDATION_EXPORT double MapboxStaticVersionNumber;

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -1,5 +1,9 @@
 import CoreLocation
-import UIKit
+#if os(iOS)
+    import UIKit
+#elseif os(OSX)
+    import Cocoa
+#endif
 
 let allowedCharacterSet: NSCharacterSet = {
     let characterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
@@ -14,7 +18,12 @@ public enum MarkerSize: String {
 }
 
 public class Overlay: CustomStringConvertible {
-
+    #if os(iOS)
+    public typealias Color = UIColor
+    #elseif os(OSX)
+    public typealias Color = NSColor
+    #endif
+    
     internal var requestString: String = ""
     
     public var description: String {
@@ -24,11 +33,10 @@ public class Overlay: CustomStringConvertible {
 }
 
 public class Marker: Overlay {
-
     public init(coordinate: CLLocationCoordinate2D,
          size: MarkerSize = .Small,
          label: String = "",
-         color: UIColor = UIColor.redColor()) {
+         color: Color = .redColor()) {
 
         super.init()
 
@@ -116,9 +124,9 @@ public class Path: Overlay {
 
     public init(pathCoordinates: [CLLocationCoordinate2D],
          strokeWidth: Int = 1,
-         strokeColor: UIColor = UIColor.colorWithHexString("555"),
+         strokeColor: Color = Color(hexString: "555"),
          strokeOpacity: Double = 1.0,
-         fillColor: UIColor = UIColor.colorWithHexString("555"),
+         fillColor: Color = Color(hexString: "555"),
          fillOpacity: Double = 0) {
 
         super.init()

--- a/MapboxStaticTests/MapboxStaticTests.swift
+++ b/MapboxStaticTests/MapboxStaticTests.swift
@@ -4,6 +4,12 @@ import CoreLocation
 import Foundation
 import MapboxStatic
 
+#if os(iOS)
+    typealias Color = UIColor
+#elseif os(OSX)
+    typealias Color = NSColor
+#endif
+
 class MapboxStaticTests: XCTestCase {
     let mapID = "justin.o0mbikn2"
     let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
@@ -38,6 +44,13 @@ class MapboxStaticTests: XCTestCase {
         let autoFitExp = expectationWithDescription("auto-fit should default to enabled")
 
         let options = SnapshotOptions(mapIdentifier: mapID, size: CGSize(width: 200, height: 200))
+        
+        let scale: CGFloat
+        #if os(iOS)
+            scale = UIScreen.mainScreen().scale
+        #elseif os(OSX)
+            scale = NSScreen.mainScreen()?.backingScaleFactor ?? 1
+        #endif
 
         stub(isHost(serviceHost)) { [unowned self] request in
             if let p = request.URL?.pathComponents {
@@ -51,11 +64,11 @@ class MapboxStaticTests: XCTestCase {
                     overlaysExp.fulfill()
                     autoFitExp.fulfill()
                 }
-                if p[4].componentsSeparatedByString(".").first == "200x200" && UIScreen.mainScreen().scale == 1 {
+                if p[4].componentsSeparatedByString(".").first == "200x200" && scale == 1 {
                     retinaExp.fulfill()
                     sizeExp.fulfill()
                 }
-                else if p[4].componentsSeparatedByString(".").first == "200x200@2x" && UIScreen.mainScreen().scale > 1 {
+                else if p[4].componentsSeparatedByString(".").first == "200x200@2x" && scale > 1 {
                     retinaExp.fulfill()
                     sizeExp.fulfill()
                 }
@@ -220,7 +233,7 @@ class MapboxStaticTests: XCTestCase {
         let lon = -122.681944
         let size = MarkerSize.Medium
         let label = "cafe"
-        let color = UIColor.brownColor()
+        let color = Color.brownColor()
         let colorRaw = "996633"
 
         let markerExp = expectationWithDescription("builtin marker argument should format Maki request properly")
@@ -324,10 +337,10 @@ class MapboxStaticTests: XCTestCase {
 
     func testOverlayPath() {
         let strokeWidth = 2
-        let strokeColor = UIColor.blackColor()
+        let strokeColor = Color.blackColor()
         let strokeColorRaw = "000000"
         let strokeOpacity = 0.75
-        let fillColor = UIColor.redColor()
+        let fillColor = Color.redColor()
         let fillColorRaw = "ff0000"
         let fillOpacity = 0.25
         let encodedPolyline = "(upztG%60jxkVn@al@bo@nFWzuAaTcAyZen@)"
@@ -392,7 +405,7 @@ class MapboxStaticTests: XCTestCase {
             coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
             size: .Medium,
             label: "cafe",
-            color: UIColor.brownColor())
+            color: .brownColor())
 
         var options = SnapshotOptions(
             mapIdentifier: mapID,

--- a/OS X.playground/Contents.swift
+++ b/OS X.playground/Contents.swift
@@ -1,0 +1,157 @@
+import CoreLocation
+import Cocoa
+import MapboxStatic
+
+/*:
+ # MapboxStatic.swift
+ 
+ MapboxStatic.swift makes it easy to connect your OS X Cocoa application to the [classic Mapbox Static API](https://www.mapbox.com/api-documentation/#static-classic). Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
+ 
+ Static maps are flattened PNG or JPG images, ideal for use in table views, image views, and anyplace else you’d like a quick, custom map without the overhead of an interactive view. They are created in one HTTP request, so overlays are all added *server-side*.
+ 
+ ## Usage
+ 
+ You will need a [map ID](https://www.mapbox.com/foundations/glossary/#mapid) from a [custom map style](https://www.mapbox.com/foundations/customizing-the-map) on your Mapbox account. You will also need an [access token](https://www.mapbox.com/developers/api/#access-tokens) in order to use the API.
+ 
+ You can specify your access token inline or by setting the `MGLMapboxAccessToken` key in your application’s Info.plist file.
+ */
+
+let mapIdentifier = "justin.tm2-basemap"
+let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
+
+/*:
+ ## Basics
+ 
+ The main static map class is `Snapshot`. To create a basic snapshot, create a `SnapshotOptions` object, specifying the center coordinates, [zoom level](https://www.mapbox.com/guides/how-web-maps-work/#tiles-and-zoom-levels), and point size:
+ */
+
+var options = SnapshotOptions(
+    mapIdentifier: mapIdentifier,
+    centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
+    zoomLevel: 13,
+    size: CGSize(width: 300, height: 200))
+var snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+
+/*:
+ Then, you can either retrieve an image synchronously (blocking the calling thread):
+ */
+snapshot.image
+
+/*:
+ Or you can pass a completion handler to update the UI thread after the image is retrieved:
+ */
+let imageView = NSImageView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+snapshot.image { (image, error) in
+    imageView.image = image
+}
+
+/*:
+ If you’re using your own HTTP library or routines, you can also retrieve a snapshot’s `requestURL` property.
+ */
+snapshot.requestURL
+
+/*:
+ ## Overlays
+ 
+ Overlays are where things get interesting! You can add [Maki markers](https://www.mapbox.com/maki/), custom marker imagery, GeoJSON geometries, and even paths made of bare coordinates.
+ 
+ You add overlays to the `overlays` field in the `SnapshotOptions` object. Here are some versions of our snapshot with various overlays added.
+ 
+ ### Marker
+ */
+let markerOverlay = Marker(
+    coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
+    size: .Medium,
+    label: "cafe",
+    color: .brownColor())
+options.overlays = [markerOverlay]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### Custom marker
+ */
+let customMarker = CustomMarker(
+    coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
+    URL: NSURL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!)
+options.overlays = [customMarker]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### GeoJSON
+ */
+let geojsonOverlay: GeoJSON
+do {
+    let geojsonURL = NSURL(string: "http://git.io/vCv9U")!
+    let geojsonString = try NSString(contentsOfURL: geojsonURL, encoding: NSUTF8StringEncoding)
+    geojsonOverlay = GeoJSON(string: geojsonString as String)
+}
+options.overlays = [geojsonOverlay]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### Path
+ */
+let path = Path(
+    pathCoordinates: [
+        CLLocationCoordinate2D(
+            latitude: 45.52475063103141,
+            longitude: -122.68209457397461),
+        CLLocationCoordinate2D(
+            latitude: 45.52451009822193,
+            longitude: -122.67488479614258),
+        CLLocationCoordinate2D(
+            latitude: 45.51681250530043,
+            longitude: -122.67608642578126),
+        CLLocationCoordinate2D(
+            latitude: 45.51693278828882,
+            longitude: -122.68999099731445),
+        CLLocationCoordinate2D(
+            latitude: 45.520300607576864,
+            longitude: -122.68964767456055),
+        CLLocationCoordinate2D(
+            latitude: 45.52475063103141,
+            longitude: -122.68209457397461),
+    ],
+    strokeWidth: 2,
+    strokeColor: .blackColor(),
+    fillColor: .redColor(),
+    fillOpacity: 0.25)
+options.overlays = [path]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ## Other options
+ 
+ ### Auto-fitting features
+ 
+ If you’re adding overlays to your map, leave out the center coordinate and zoom level to automatically calculate the center and zoom level that best shows them off.
+ */
+options.overlays = [path, geojsonOverlay, markerOverlay, customMarker]
+snapshot = Snapshot(
+    options: options,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
+ ### File format and quality
+ 
+ When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).
+ 
+ ### Attribution
+ 
+ Be sure to [attribute your map](https://www.mapbox.com/api-documentation/#static-classic) properly in your app. You can also [find out more](https://www.mapbox.com/about/maps/) about where Mapbox’s map data comes from.
+ */

--- a/OS X.playground/contents.xcplayground
+++ b/OS X.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='osx' display-mode='raw'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,3 @@
-platform :ios, '8.0'
 use_frameworks!
 
 #def shared_pods
@@ -9,6 +8,13 @@ use_frameworks!
 #end
 
 target 'MapboxStaticTests' do
+  platform :ios, '8.0'
+  pod 'OHHTTPStubs/Swift', '~> 4.4.0'
+#  shared_pods
+end
+
+target 'MapboxStaticMacTests' do
+  platform :osx, '10.10'
   pod 'OHHTTPStubs/Swift', '~> 4.4.0'
 #  shared_pods
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://www.bitrise.io/app/faa9d29af3e2ce7a.svg?token=_oJK999amHl5HlK3a82PZA&branch=master)](https://www.bitrise.io/app/faa9d29af3e2ce7a)
 
-MapboxStatic.swift makes it easy to connect your iOS, tvOS, or watchOS application to the [classic Mapbox Static API](https://www.mapbox.com/api-documentation/#static-classic). Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
+MapboxStatic.swift makes it easy to connect your iOS, OS X, tvOS, or watchOS application to the [classic Mapbox Static API](https://www.mapbox.com/api-documentation/#static-classic). Quickly generate a static map image with overlays, asynchronous imagery fetching, and first-class Swift data types.
 
 Static maps are flattened PNG or JPG images, ideal for use in table views, image views, and anyplace else you'd like a quick, custom map without the overhead of an interactive view. They are created in one HTTP request, so overlays are all added *server-side*.
 


### PR DESCRIPTION
Added framework and test bundle targets for OS X. Strategically placed some type aliases to keep conditional compilation to a minimum. Added a playground nearly identical to the iOS one.

Fixes #15.