### PR TITLE
Allow multiple map identifiers

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
         super.viewDidAppear(animated)
         
         let options = SnapshotOptions(
-            mapIdentifier: "justin.tm2-basemap",
+            mapIdentifiers: ["justin.tm2-basemap"],
             centerCoordinate: CLLocationCoordinate2D(latitude: 45, longitude: -122),
             zoomLevel: 6,
             size: imageView.bounds.size)

--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -19,10 +19,18 @@ public enum SnapshotFormat: String {
     public static let allValues = [PNG, PNG256, PNG128, PNG64, PNG32, JPEG, JPEG90, JPEG80, JPEG70]
 }
 
+/**
+ A structure that determines what a snapshot depicts and how it is formatted.
+ */
 public struct SnapshotOptions {
     // MARK: Configuring the Map Data
     
-    public var mapIdentifier: String
+    /**
+     An array of map identifiers of the form `username.id`, identifying the tile sets to display in the snapshot. This array may not be empty.
+     
+     The order of the map identifiers in the array reflects their visible order in the snapshot, with the tile set identified at index 0 being the backmost tile set.
+     */
+    public var mapIdentifiers: [String]
     public var overlays: [Overlay] = []
     public var centerCoordinate: CLLocationCoordinate2D? = nil
     public var zoomLevel: Int?
@@ -39,19 +47,22 @@ public struct SnapshotOptions {
     public var showsAttribution: Bool = true
     public var showsLogo: Bool = true
     
-    public init(mapIdentifier: String, size: CGSize) {
-        self.mapIdentifier = mapIdentifier
+    public init(mapIdentifiers: [String], size: CGSize) {
+        self.mapIdentifiers = mapIdentifiers
         self.size = size
     }
     
-    public init(mapIdentifier: String, centerCoordinate: CLLocationCoordinate2D, zoomLevel: Int, size: CGSize) {
-        self.mapIdentifier = mapIdentifier
+    public init(mapIdentifiers: [String], centerCoordinate: CLLocationCoordinate2D, zoomLevel: Int, size: CGSize) {
+        self.mapIdentifiers = mapIdentifiers
         self.centerCoordinate = centerCoordinate
         self.zoomLevel = zoomLevel
         self.size = size
     }
     
     private var path: String {
+        assert(!mapIdentifiers.isEmpty, "At least one map identifier must be specified.")
+        let tileSetComponent = mapIdentifiers.joinWithSeparator(",")
+        
         let position: String
         if let centerCoordinate = centerCoordinate {
             position = "\(centerCoordinate.longitude),\(centerCoordinate.latitude),\(zoomLevel ?? 0)"
@@ -66,7 +77,7 @@ public struct SnapshotOptions {
             overlaysComponent = "/" + overlays.map { return "\($0)" }.joinWithSeparator(",")
         }
         
-        return "/v4/\(mapIdentifier)\(overlaysComponent)/\(position)/\(Int(round(size.width)))x\(Int(round(size.height)))\(scale > 1 ? "@2x" : "").\(format.rawValue)"
+        return "/v4/\(tileSetComponent)\(overlaysComponent)/\(position)/\(Int(round(size.width)))x\(Int(round(size.height)))\(scale > 1 ? "@2x" : "").\(format.rawValue)"
     }
     
     private var params: [NSURLQueryItem] {

--- a/MapboxStaticTests/MapboxStaticTests.swift
+++ b/MapboxStaticTests/MapboxStaticTests.swift
@@ -11,7 +11,7 @@ import MapboxStatic
 #endif
 
 class MapboxStaticTests: XCTestCase {
-    let mapID = "justin.o0mbikn2"
+    let mapIdentifiers = ["justin.o0mbikn2"]
     let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
     let serviceHost = "api.mapbox.com"
     
@@ -43,7 +43,7 @@ class MapboxStaticTests: XCTestCase {
         let overlaysExp = expectationWithDescription("overlays should default to empty")
         let autoFitExp = expectationWithDescription("auto-fit should default to enabled")
 
-        let options = SnapshotOptions(mapIdentifier: mapID, size: CGSize(width: 200, height: 200))
+        let options = SnapshotOptions(mapIdentifiers: mapIdentifiers, size: CGSize(width: 200, height: 200))
         
         let scale: CGFloat
         #if os(iOS)
@@ -57,7 +57,7 @@ class MapboxStaticTests: XCTestCase {
                 if p[1] == "v4" {
                     versionExp.fulfill()
                 }
-                if p[2] == self.mapID {
+                if p[2] == self.mapIdentifiers.joinWithSeparator(",") {
                     mapIDExp.fulfill()
                 }
                 if p[3] == "auto" {
@@ -98,7 +98,7 @@ class MapboxStaticTests: XCTestCase {
         let centerExp = expectationWithDescription("center should get passed intact")
 
         let options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             centerCoordinate: center,
             zoomLevel: 0,
             size: CGSize(width: 200, height: 200))
@@ -125,7 +125,7 @@ class MapboxStaticTests: XCTestCase {
         let zoomExp = expectationWithDescription("zoom should get passed intact")
 
         let options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             centerCoordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
             zoomLevel: zoom,
             size: CGSize(width: 300, height: 300))
@@ -156,7 +156,7 @@ class MapboxStaticTests: XCTestCase {
         let sizeExp = expectationWithDescription("size should pass intact for non-retina")
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: CGFloat(width), height: CGFloat(height)))
         options.scale = 1
 
@@ -190,7 +190,7 @@ class MapboxStaticTests: XCTestCase {
             }
 
             var options = SnapshotOptions(
-                mapIdentifier: mapID,
+                mapIdentifiers: mapIdentifiers,
                 size: CGSize(width: 200, height: 200))
             options.format = format
             optionses.append(options)
@@ -207,7 +207,7 @@ class MapboxStaticTests: XCTestCase {
         let retinaExp = expectationWithDescription("retina should request @2x asset")
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.scale = 2
 
@@ -245,7 +245,7 @@ class MapboxStaticTests: XCTestCase {
             color: color)
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [markerOverlay]
 
@@ -276,7 +276,7 @@ class MapboxStaticTests: XCTestCase {
             URL: markerURL)
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [customMarker]
 
@@ -313,7 +313,7 @@ class MapboxStaticTests: XCTestCase {
         let geojsonOverlay = GeoJSON(string: geojsonString as String)
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [geojsonOverlay]
 
@@ -375,7 +375,7 @@ class MapboxStaticTests: XCTestCase {
         let pathExp = expectationWithDescription("raw path argument should properly encode request")
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [path]
 
@@ -408,7 +408,7 @@ class MapboxStaticTests: XCTestCase {
             color: .brownColor())
 
         var options = SnapshotOptions(
-            mapIdentifier: mapID,
+            mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [markerOverlay]
 

--- a/OS X.playground/Contents.swift
+++ b/OS X.playground/Contents.swift
@@ -16,7 +16,7 @@ import MapboxStatic
  You can specify your access token inline or by setting the `MGLMapboxAccessToken` key in your application’s Info.plist file.
  */
 
-let mapIdentifier = "justin.tm2-basemap"
+let mapIdentifiers = ["justin.tm2-basemap"]
 let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
 
 /*:
@@ -26,7 +26,7 @@ let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-H
  */
 
 var options = SnapshotOptions(
-    mapIdentifier: mapIdentifier,
+    mapIdentifiers: mapIdentifiers,
     centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
     zoomLevel: 13,
     size: CGSize(width: 300, height: 200))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The main static map class is `Snapshot`. To create a basic snapshot, create a `S
 import MapboxStatic
 
 let options = SnapshotOptions(
-    mapIdentifier: "<#your map ID#>",
+    mapIdentifiers: ["<#your map ID#>"],
     centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
     zoomLevel: 13,
     size: CGSize(width: 200, height: 200))
@@ -145,7 +145,7 @@ If you’re adding overlays to your map, leave out the center coordinate and zoo
 
 ```swift
 var options = SnapshotOptions(
-    mapIdentifier: "<#your map ID#>",
+    mapIdentifiers: ["<#your map ID#>"],
     size: CGSize(width: 500, height: 300))
 options.overlays = [path, geojsonOverlay, markerOverlay, customMarker]
 ```

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -16,7 +16,7 @@ import MapboxStatic
  You can specify your access token inline or by setting the `MGLMapboxAccessToken` key in your application’s Info.plist file.
  */
 
-let mapIdentifier = "justin.tm2-basemap"
+let mapIdentifiers = ["justin.tm2-basemap"]
 let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"
 
 /*:
@@ -26,7 +26,7 @@ let accessToken = "pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-H
  */
 
 var options = SnapshotOptions(
-    mapIdentifier: mapIdentifier,
+    mapIdentifiers: mapIdentifiers,
     centerCoordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
     zoomLevel: 13,
     size: CGSize(width: 300, height: 200))

--- a/iOS.playground/timeline.xctimeline
+++ b/iOS.playground/timeline.xctimeline
@@ -3,32 +3,32 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1846&amp;EndingColumnNumber=15&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1835&amp;EndingColumnNumber=15&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=484939570.791401"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2896&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2885&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=484939570.79166"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3240&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3229&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=484939570.791862"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3638&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3627&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=484939570.792055"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4630&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4619&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=484939570.792244"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5013&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=484733350.240847"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5002&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=484939570.79247"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
It was always possible to composite tile sets by setting the `mapIdentifier` field to a comma-separated list of map IDs. But this change formalizes compositing by replacing the string `mapIdentifier` field with an array-of-strings `mapIdentifiers` field.