### PR TITLE
URL-escape polyline-encoded overlay

### DIFF
--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -6,7 +6,7 @@ import CoreLocation
 #endif
 
 let allowedCharacterSet: NSCharacterSet = {
-    let characterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+    let characterSet = NSCharacterSet.URLPathAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
     characterSet.removeCharactersInString("/")
     return characterSet
 }()
@@ -308,7 +308,7 @@ public struct Path: Overlay {
     }
     
     public var description: String {
-        let encodedPolyline = polylineEncode(coordinates)
+        let encodedPolyline = polylineEncode(coordinates).stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
         return "path-\(strokeWidth)+\(strokeColor.toHexString())-\(strokeOpacity)+\(fillColor.toHexString())-\(fillOpacity)(\(encodedPolyline))"
     }
 }

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -7,7 +7,7 @@ import CoreLocation
 
 let allowedCharacterSet: NSCharacterSet = {
     let characterSet = NSCharacterSet.URLPathAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
-    characterSet.removeCharactersInString("/")
+    characterSet.removeCharactersInString("/)")
     return characterSet
 }()
 
@@ -304,7 +304,7 @@ public struct Path: Overlay {
             output += encodeCoordinate(a.longitude - b.longitude)
         }
 
-        return output.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        return output
     }
     
     public var description: String {


### PR DESCRIPTION
Fixed an issue in which polyline-encoded strings containing `?` would truncate the URL path, putting the rest of the path into the query string, causing the image request to fail due to a “missing access token”. This change applies a stricter allowed character set to path components.

/cc @tmcw