### PR TITLE
Fix assertion failure on 3× devices

### DIFF
--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -163,8 +163,8 @@ public struct SnapshotOptions {
             assert(zoomLevel <= 20, "maximum zoom is 20")
         }
         
-        assert(size.width  * scale <= 1_280, "maximum width is 1,280 pixels (640 points @2×)")
-        assert(size.height * scale <= 1_280, "maximum height is 1,280 pixels (640 points @2×)")
+        assert(size.width  * min(scale, 2) <= 1_280, "maximum width is 1,280 pixels (640 points @2×)")
+        assert(size.height * min(scale, 2) <= 1_280, "maximum height is 1,280 pixels (640 points @2×)")
         
         assert(overlays.count <= 100, "maximum number of overlays is 100")
         


### PR DESCRIPTION
An assertion that the size doesn’t exceed the allowable limits accounted for the scale but not for the fact that the scale is actually capped at 2× before sending the request. This change adjusts the assertion to allow 3× screens to load images as large as are allowed on 2× screens.