### PR TITLE
Add support for bridging to Objective-C

### DIFF
--- a/Example/AppDelegate.h
+++ b/Example/AppDelegate.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+@end

--- a/Example/AppDelegate.m
+++ b/Example/AppDelegate.m
@@ -1,0 +1,16 @@
+#import "AppDelegate.h"
+#import "ViewController.h"
+
+@interface AppDelegate ()
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window.rootViewController = [[ViewController alloc] init];
+    [self.window makeKeyAndVisible];
+    return YES;
+}
+
+@end

--- a/Example/ViewController.h
+++ b/Example/ViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+@end

--- a/Example/ViewController.m
+++ b/Example/ViewController.m
@@ -1,0 +1,46 @@
+#import "ViewController.h"
+
+@import CoreLocation;
+@import MapboxStatic;
+
+// You can also specify the access token with the `MGLMapboxAccessToken` key in Info.plist.
+static NSString * const AccessToken = @"pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A";
+
+@interface ViewController ()
+
+@property (nonatomic, strong) UIImageView *imageView;
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.imageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
+    self.imageView.backgroundColor = [UIColor blackColor];
+    [self.view addSubview:self.imageView];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    MBSnapshotOptions *options = [[MBSnapshotOptions alloc] initWithMapIdentifiers:@[@"justin.tm2-basemap"]
+                                                                  centerCoordinate:CLLocationCoordinate2DMake(45, -122)
+                                                                         zoomLevel:6
+                                                                              size:self.imageView.bounds.size];
+    CLLocationCoordinate2D coords[] = {
+        CLLocationCoordinate2DMake(45, -122),
+        CLLocationCoordinate2DMake(45, -124),
+    };
+    MBPath *path = [[MBPath alloc] initWithCoordinates:coords count:sizeof(coords) / sizeof(coords[0])];
+    options.overlays = @[path];
+    MBSnapshot *snapshot = [[MBSnapshot alloc] initWithOptions:options accessToken:AccessToken];
+    __weak typeof(self) weakSelf = self;
+    [snapshot imageWithCompletionHandler:^(UIImage * _Nullable image, NSError * _Nullable error) {
+        typeof(weakSelf) strongSelf = weakSelf;
+        strongSelf.imageView.image = image;
+    }];
+}
+
+@end

--- a/Example/main.m
+++ b/Example/main.m
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -33,6 +33,11 @@
 		DAF15A441CE8FBBC0040E86C /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD19871BD9B3970057AC9F /* Snapshot.swift */; };
 		DAF15A451CE8FBBC0040E86C /* Overlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20FBAB1CE4026B00B07762 /* Overlay.swift */; };
 		DAF15A461CE8FBBC0040E86C /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20FBA91CE401E800B07762 /* Color.swift */; };
+		DAF15A4F1CE90A6C0040E86C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF15A4E1CE90A6C0040E86C /* main.m */; };
+		DAF15A521CE90A6C0040E86C /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF15A511CE90A6C0040E86C /* AppDelegate.m */; };
+		DAF15A551CE90A6C0040E86C /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DAF15A541CE90A6C0040E86C /* ViewController.m */; };
+		DAF15A631CE90CE70040E86C /* MapboxStatic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */; };
+		DAF15A641CE90CE70040E86C /* MapboxStatic.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DD0C88181BE1A9E100606E9F /* polyline.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DD0C88161BE1A9D400606E9F /* polyline.geojson */; };
 		DD685BA91BDB14C1002E2BB2 /* MapboxStaticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD19831BD9B2F80057AC9F /* MapboxStaticTests.swift */; };
 		DDAD19711BD9B1A50057AC9F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */; };
@@ -62,6 +67,13 @@
 			remoteGlobalIDString = DA4B4B911CE8F83100296A52;
 			remoteInfo = MapboxStaticTV;
 		};
+		DAF15A651CE90CE70040E86C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDAD19511BD9B1780057AC9F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA20FB9A1CE3DEBB00B07762;
+			remoteInfo = MapboxStatic;
+		};
 		DDAD197D1BD9B24F0057AC9F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DDAD19511BD9B1780057AC9F /* Project object */;
@@ -79,6 +91,17 @@
 			dstSubfolderSpec = 10;
 			files = (
 				DA20FBA31CE3DEBB00B07762 /* MapboxStatic.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAF15A671CE90CE70040E86C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				DAF15A641CE90CE70040E86C /* MapboxStatic.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -105,8 +128,14 @@
 		DA4B4B921CE8F83100296A52 /* MapboxStatic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxStatic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA4B4B9B1CE8F83100296A52 /* MapboxStaticTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxStaticTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAF15A3B1CE8FB8D0040E86C /* MapboxStatic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxStatic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAF15A4B1CE90A6C0040E86C /* MapboxStatic (Objective-C).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MapboxStatic (Objective-C).app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAF15A4E1CE90A6C0040E86C /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		DAF15A501CE90A6C0040E86C /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		DAF15A511CE90A6C0040E86C /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		DAF15A531CE90A6C0040E86C /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		DAF15A541CE90A6C0040E86C /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		DD0C88161BE1A9D400606E9F /* polyline.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = polyline.geojson; sourceTree = "<group>"; };
-		DDAD19591BD9B1780057AC9F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDAD19591BD9B1780057AC9F /* MapboxStatic (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MapboxStatic (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DDAD196F1BD9B1A50057AC9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DDAD19701BD9B1A50057AC9F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -165,6 +194,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAF15A481CE90A6C0040E86C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAF15A631CE90CE70040E86C /* MapboxStatic.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DDAD19561BD9B1780057AC9F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -219,6 +256,27 @@
 			path = MapboxStatic;
 			sourceTree = "<group>";
 		};
+		DAF15A4C1CE90A6C0040E86C /* Objective-C */ = {
+			isa = PBXGroup;
+			children = (
+				DAF15A501CE90A6C0040E86C /* AppDelegate.h */,
+				DAF15A511CE90A6C0040E86C /* AppDelegate.m */,
+				DAF15A531CE90A6C0040E86C /* ViewController.h */,
+				DAF15A541CE90A6C0040E86C /* ViewController.m */,
+				DAF15A4E1CE90A6C0040E86C /* main.m */,
+			);
+			name = "Objective-C";
+			sourceTree = "<group>";
+		};
+		DAF15A621CE90AA60040E86C /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */,
+				DDAD19701BD9B1A50057AC9F /* ViewController.swift */,
+			);
+			name = Swift;
+			sourceTree = "<group>";
+		};
 		DD0C88151BE1A9CC00606E9F /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,7 +303,7 @@
 		DDAD195A1BD9B1780057AC9F /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DDAD19591BD9B1780057AC9F /* Example.app */,
+				DDAD19591BD9B1780057AC9F /* MapboxStatic (Swift).app */,
 				DDAD19781BD9B24F0057AC9F /* MapboxStaticTests.xctest */,
 				DA20FB9B1CE3DEBB00B07762 /* MapboxStatic.framework */,
 				DA20FBB91CE4757E00B07762 /* MapboxStatic.framework */,
@@ -253,6 +311,7 @@
 				DA4B4B921CE8F83100296A52 /* MapboxStatic.framework */,
 				DA4B4B9B1CE8F83100296A52 /* MapboxStaticTests.xctest */,
 				DAF15A3B1CE8FB8D0040E86C /* MapboxStatic.framework */,
+				DAF15A4B1CE90A6C0040E86C /* MapboxStatic (Objective-C).app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -260,8 +319,8 @@
 		DDAD195B1BD9B1780057AC9F /* Example */ = {
 			isa = PBXGroup;
 			children = (
-				DDAD196E1BD9B1A50057AC9F /* AppDelegate.swift */,
-				DDAD19701BD9B1A50057AC9F /* ViewController.swift */,
+				DAF15A621CE90AA60040E86C /* Swift */,
+				DAF15A4C1CE90A6C0040E86C /* Objective-C */,
 				DDAD196F1BD9B1A50057AC9F /* Info.plist */,
 			);
 			path = Example;
@@ -429,9 +488,28 @@
 			productReference = DAF15A3B1CE8FB8D0040E86C /* MapboxStatic.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		DDAD19581BD9B1780057AC9F /* Example */ = {
+		DAF15A4A1CE90A6C0040E86C /* Example (Objective-C) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example" */;
+			buildConfigurationList = DAF15A5F1CE90A6C0040E86C /* Build configuration list for PBXNativeTarget "Example (Objective-C)" */;
+			buildPhases = (
+				DAF15A471CE90A6C0040E86C /* Sources */,
+				DAF15A481CE90A6C0040E86C /* Frameworks */,
+				DAF15A491CE90A6C0040E86C /* Resources */,
+				DAF15A671CE90CE70040E86C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DAF15A661CE90CE70040E86C /* PBXTargetDependency */,
+			);
+			name = "Example (Objective-C)";
+			productName = ExampleObjC;
+			productReference = DAF15A4B1CE90A6C0040E86C /* MapboxStatic (Objective-C).app */;
+			productType = "com.apple.product-type.application";
+		};
+		DDAD19581BD9B1780057AC9F /* Example (Swift) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example (Swift)" */;
 			buildPhases = (
 				DDAD19551BD9B1780057AC9F /* Sources */,
 				DDAD19561BD9B1780057AC9F /* Frameworks */,
@@ -443,9 +521,9 @@
 			dependencies = (
 				DA20FBA11CE3DEBB00B07762 /* PBXTargetDependency */,
 			);
-			name = Example;
+			name = "Example (Swift)";
 			productName = "Sample App";
-			productReference = DDAD19591BD9B1780057AC9F /* Example.app */;
+			productReference = DDAD19591BD9B1780057AC9F /* MapboxStatic (Swift).app */;
 			productType = "com.apple.product-type.application";
 		};
 		DDAD19771BD9B24F0057AC9F /* MapboxStaticTests */ = {
@@ -497,6 +575,9 @@
 					DAF15A3A1CE8FB8D0040E86C = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
+					DAF15A4A1CE90A6C0040E86C = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					DDAD19581BD9B1780057AC9F = {
 						CreatedOnToolsVersion = 7.1;
 					};
@@ -518,7 +599,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				DDAD19581BD9B1780057AC9F /* Example */,
+				DDAD19581BD9B1780057AC9F /* Example (Swift) */,
+				DAF15A4A1CE90A6C0040E86C /* Example (Objective-C) */,
 				DA20FB9A1CE3DEBB00B07762 /* MapboxStatic */,
 				DDAD19771BD9B24F0057AC9F /* MapboxStaticTests */,
 				DA20FBB81CE4757E00B07762 /* MapboxStaticMac */,
@@ -569,6 +651,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DAF15A391CE8FB8D0040E86C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAF15A491CE90A6C0040E86C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -787,6 +876,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAF15A471CE90A6C0040E86C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAF15A551CE90A6C0040E86C /* ViewController.m in Sources */,
+				DAF15A521CE90A6C0040E86C /* AppDelegate.m in Sources */,
+				DAF15A4F1CE90A6C0040E86C /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DDAD19551BD9B1780057AC9F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -822,9 +921,14 @@
 			target = DA4B4B911CE8F83100296A52 /* MapboxStaticTV */;
 			targetProxy = DA4B4B9D1CE8F83100296A52 /* PBXContainerItemProxy */;
 		};
+		DAF15A661CE90CE70040E86C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA20FB9A1CE3DEBB00B07762 /* MapboxStatic */;
+			targetProxy = DAF15A651CE90CE70040E86C /* PBXContainerItemProxy */;
+		};
 		DDAD197E1BD9B24F0057AC9F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = DDAD19581BD9B1780057AC9F /* Example */;
+			target = DDAD19581BD9B1780057AC9F /* Example (Swift) */;
 			targetProxy = DDAD197D1BD9B24F0057AC9F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1072,6 +1176,32 @@
 			};
 			name = Release;
 		};
+		DAF15A601CE90A6C0040E86C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = Example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.ObjC;
+				PRODUCT_NAME = "MapboxStatic (Objective-C)";
+			};
+			name = Debug;
+		};
+		DAF15A611CE90A6C0040E86C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = Example/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.ObjC;
+				PRODUCT_NAME = "MapboxStatic (Objective-C)";
+			};
+			name = Release;
+		};
 		DDAD19691BD9B1780057AC9F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1165,8 +1295,8 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
+				PRODUCT_NAME = "MapboxStatic (Swift)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1179,8 +1309,8 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticExample;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
+				PRODUCT_NAME = "MapboxStatic (Swift)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -1267,6 +1397,16 @@
 				DAF15A411CE8FB8D0040E86C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAF15A5F1CE90A6C0040E86C /* Build configuration list for PBXNativeTarget "Example (Objective-C)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAF15A601CE90A6C0040E86C /* Debug */,
+				DAF15A611CE90A6C0040E86C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DDAD19541BD9B1780057AC9F /* Build configuration list for PBXProject "MapboxStatic" */ = {
 			isa = XCConfigurationList;
@@ -1277,7 +1417,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example" */ = {
+		DDAD196B1BD9B1780057AC9F /* Build configuration list for PBXNativeTarget "Example (Swift)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DDAD196C1BD9B1780057AC9F /* Debug */,

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
-               BuildableName = "Example.app"
-               BlueprintName = "Example"
+               BlueprintIdentifier = "DAF15A4A1CE90A6C0040E86C"
+               BuildableName = "MapboxStatic (Objective-C).app"
+               BlueprintName = "Example (Objective-C)"
                ReferencedContainer = "container:MapboxStatic.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,16 +26,15 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
+            BlueprintIdentifier = "DAF15A4A1CE90A6C0040E86C"
+            BuildableName = "MapboxStatic (Objective-C).app"
+            BlueprintName = "Example (Objective-C)"
             ReferencedContainer = "container:MapboxStatic.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -56,9 +55,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
+            BlueprintIdentifier = "DAF15A4A1CE90A6C0040E86C"
+            BuildableName = "MapboxStatic (Objective-C).app"
+            BlueprintName = "Example (Objective-C)"
             ReferencedContainer = "container:MapboxStatic.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -75,9 +74,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
-            BuildableName = "Example.app"
-            BlueprintName = "Example"
+            BlueprintIdentifier = "DAF15A4A1CE90A6C0040E86C"
+            BuildableName = "MapboxStatic (Objective-C).app"
+            BlueprintName = "Example (Objective-C)"
             ReferencedContainer = "container:MapboxStatic.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
+               BuildableName = "MapboxStatic (Swift).app"
+               BlueprintName = "Example (Swift)"
+               ReferencedContainer = "container:MapboxStatic.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
+            BuildableName = "MapboxStatic (Swift).app"
+            BlueprintName = "Example (Swift)"
+            ReferencedContainer = "container:MapboxStatic.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
+            BuildableName = "MapboxStatic (Swift).app"
+            BlueprintName = "Example (Swift)"
+            ReferencedContainer = "container:MapboxStatic.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DDAD19581BD9B1780057AC9F"
+            BuildableName = "MapboxStatic (Swift).app"
+            BlueprintName = "Example (Swift)"
+            ReferencedContainer = "container:MapboxStatic.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxStatic/Color.swift
+++ b/MapboxStatic/Color.swift
@@ -31,12 +31,9 @@ internal extension Color {
     convenience init(hexString: String) {
         var hexString = hexString.stringByReplacingOccurrencesOfString("#", withString: "")
 
-        if hexString.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == 3 {
-            let r = Array(arrayLiteral: hexString)[0]
-            let g = Array(arrayLiteral: hexString)[1]
-            let b = Array(arrayLiteral: hexString)[2]
-
-            hexString = r + r + g + g + b + b
+        if hexString.characters.count == 3 {
+            let digits = Array(hexString.characters)
+            hexString = "\(digits[0])\(digits[0])\(digits[1])\(digits[1])\(digits[2])\(digits[2])"
         }
 
         var r: CGFloat = 0

--- a/MapboxStatic/MapboxStatic.h
+++ b/MapboxStatic/MapboxStatic.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
 
 //! Project version number for MapboxStatic.
 FOUNDATION_EXPORT double MapboxStaticVersionNumber;

--- a/MapboxStaticTests/MapboxStaticTests.swift
+++ b/MapboxStaticTests/MapboxStaticTests.swift
@@ -155,7 +155,7 @@ class MapboxStaticTests: XCTestCase {
 
         let sizeExp = expectationWithDescription("size should pass intact for non-retina")
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: CGFloat(width), height: CGFloat(height)))
         options.scale = 1
@@ -184,23 +184,39 @@ class MapboxStaticTests: XCTestCase {
             .PNG, .PNG32, .PNG64, .PNG128, .PNG256,
             .JPEG, .JPEG70, .JPEG80, .JPEG90,
         ]
-        switch allFormats[0] {
-        case .PNG, .PNG32, .PNG64, .PNG128, .PNG256,
-             .JPEG, .JPEG70, .JPEG80, .JPEG90:
-            break
-        // If you get a “Switch must be exhaustive, consider adding a default clause” error here, allFormats is missing a format.
-        }
         
         for format in allFormats {
             let exp = expectationWithDescription("\(format.rawValue) extension should be requested")
             expectations.append(exp)
 
-            stub(isExtension(format.rawValue)) { request in
+            let pathExtension: String
+            switch format {
+            case .PNG:
+                pathExtension = "png"
+            case .PNG32:
+                pathExtension = "png32"
+            case .PNG64:
+                pathExtension = "png64"
+            case .PNG128:
+                pathExtension = "png128"
+            case .PNG256:
+                pathExtension = "png256"
+            case .JPEG:
+                pathExtension = "jpg"
+            case .JPEG70:
+                pathExtension = "jpg70"
+            case .JPEG80:
+                pathExtension = "jpg80"
+            case .JPEG90:
+                pathExtension = "jpg90"
+            // If you get a “Switch must be exhaustive, consider adding a default clause” error here, allFormats is also missing a format.
+            }
+            stub(isExtension(pathExtension)) { request in
                 exp.fulfill()
                 return OHHTTPStubsResponse()
             }
 
-            var options = SnapshotOptions(
+            let options = SnapshotOptions(
                 mapIdentifiers: mapIdentifiers,
                 size: CGSize(width: 200, height: 200))
             options.format = format
@@ -217,7 +233,7 @@ class MapboxStaticTests: XCTestCase {
     func testRetina() {
         let retinaExp = expectationWithDescription("retina should request @2x asset")
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.scale = 2
@@ -242,7 +258,7 @@ class MapboxStaticTests: XCTestCase {
     func testOverlayBuiltinMarker() {
         let lat = 45.52
         let lon = -122.681944
-        let size = Marker.Size.Medium
+        let size = "m"
         let label = "cafe"
         let color = Color.brownColor()
         let colorRaw = "996633"
@@ -251,18 +267,18 @@ class MapboxStaticTests: XCTestCase {
 
         let markerOverlay = Marker(
             coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
-            size: size,
-            label: .IconName("cafe"),
-            color: color)
+            size: .Medium,
+            iconName: "cafe")
+        markerOverlay.color = color
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [markerOverlay]
 
         stub(isHost(serviceHost)) { request in
             if let p = request.URL?.pathComponents
-              where p[3] == "pin-" + size.rawValue + "-" + label +
+              where p[3] == "pin-" + size + "-" + label +
                             "+" + colorRaw + "(\(lon),\(lat))" {
                 markerExp.fulfill()
             }
@@ -286,7 +302,7 @@ class MapboxStaticTests: XCTestCase {
             coordinate: coordinate,
             URL: markerURL)
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [customMarker]
@@ -323,7 +339,7 @@ class MapboxStaticTests: XCTestCase {
         let geojsonString = try! NSString(contentsOfURL: geojsonURL, encoding: NSUTF8StringEncoding)
         let geojsonOverlay = GeoJSON(objectString: geojsonString as String)
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [geojsonOverlay]
@@ -376,16 +392,16 @@ class MapboxStaticTests: XCTestCase {
                 CLLocationCoordinate2D(
                     latitude: 45.52475063103141, longitude: -122.68209457397461
                 )
-            ],
-            strokeWidth: strokeWidth,
-            strokeColor: strokeColor,
-            strokeOpacity: strokeOpacity,
-            fillColor: fillColor,
-            fillOpacity: fillOpacity)
+            ])
+        path.strokeWidth = strokeWidth
+        path.strokeColor = strokeColor
+        path.strokeOpacity = strokeOpacity
+        path.fillColor = fillColor
+        path.fillOpacity = fillOpacity
 
         let pathExp = expectationWithDescription("raw path argument should properly encode request")
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [path]
@@ -415,10 +431,10 @@ class MapboxStaticTests: XCTestCase {
         let markerOverlay = Marker(
             coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
             size: .Medium,
-            label: .IconName("cafe"),
-            color: .brownColor())
+            iconName: "cafe")
+        markerOverlay.color = .brownColor()
 
-        var options = SnapshotOptions(
+        let options = SnapshotOptions(
             mapIdentifiers: mapIdentifiers,
             size: CGSize(width: 200, height: 200))
         options.overlays = [markerOverlay]

--- a/OS X.playground/Contents.swift
+++ b/OS X.playground/Contents.swift
@@ -64,8 +64,8 @@ snapshot.requestURL
 let markerOverlay = Marker(
     coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
     size: .Medium,
-    label: .IconName("cafe"),
-    color: .brownColor())
+    iconName: "cafe")
+markerOverlay.color = .brownColor()
 options.overlays = [markerOverlay]
 snapshot = Snapshot(
     options: options,
@@ -122,11 +122,11 @@ let path = Path(
         CLLocationCoordinate2D(
             latitude: 45.52475063103141,
             longitude: -122.68209457397461),
-    ],
-    strokeWidth: 2,
-    strokeColor: .blackColor(),
-    fillColor: .redColor(),
-    fillOpacity: 0.25)
+    ])
+path.strokeWidth = 2
+path.strokeColor = .blackColor()
+path.fillColor = .redColor()
+path.fillOpacity = 0.25
 options.overlays = [path]
 snapshot = Snapshot(
     options: options,

--- a/OS X.playground/contents.xcplayground
+++ b/OS X.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -64,8 +64,8 @@ snapshot.requestURL
 let markerOverlay = Marker(
     coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
     size: .Medium,
-    label: .IconName("cafe"),
-    color: .brownColor())
+    iconName: "cafe")
+markerOverlay.color = .brownColor()
 options.overlays = [markerOverlay]
 snapshot = Snapshot(
     options: options,
@@ -122,11 +122,11 @@ let path = Path(
         CLLocationCoordinate2D(
             latitude: 45.52475063103141,
             longitude: -122.68209457397461),
-    ],
-    strokeWidth: 2,
-    strokeColor: .blackColor(),
-    fillColor: .redColor(),
-    fillOpacity: 0.25)
+    ])
+path.strokeWidth = 2
+path.strokeColor = .blackColor()
+path.fillColor = .redColor()
+path.fillOpacity = 0.25
 options.overlays = [path]
 snapshot = Snapshot(
     options: options,

--- a/iOS.playground/contents.xcplayground
+++ b/iOS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='raw'>
+<playground version='5.0' target-platform='ios' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/timeline.xctimeline
+++ b/iOS.playground/timeline.xctimeline
@@ -8,27 +8,52 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2896&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=484959621.216448"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2906&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=485046245.490493"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3240&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=484959621.216638"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3250&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=485046245.490617"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3644&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=484959625.958138"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3654&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=485046245.490745"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4632&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=484959628.497065"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4646&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=485046271.908279"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5015&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=484959628.497196"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5029&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485046271.908407"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4638&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=485046272.334115"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5021&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485046272.334115"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3646&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=485046272.334115"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3242&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=485046272.334115"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2898&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=485046272.334115"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
All public structs are now classes that inherit from NSObject and have prefixed Objective-C class names so they can bridge to Objective-C. Changed `let` properties to `var` properties because mutability of classes is determined on a property-by-property basis. Enums have numeric types so they can bridge too; instead of backing enum values with strings, use `switch` statements.

Added multiple convenience initializers to Snapshot because optional parameters in the designated initializer aren’t getting elided when bridging to Objective-C. Added multiple convenience initializers to Marker that take non-variant types, so that Marker.Label can be taken private.

Removed colors from overlay initializers because inner type aliases don’t bridge and duplicating initializers would be unmaintainable. Also removed other parameters from Path’s initializer since they make less sense without color parameters. Added members to Path that traffic in raw pointers instead of arrays to enable bridging to Objective-C with C arrays.

GeoJSON’s initializer is now failable instead of throwable, because an error type mismatch between the standard thrown error type and the `error` parameter of `NSJSONSerialization.dataWithJSONObject(_:options:)`.

Fixed a crash initializing a color with three-digit hexadecimal number. When the hexadecimal string is an NSString under the hood, indexing into an array literal can wind up getting garbage if the NSString is initialized with UTF-16 or other storage under the hood.

Added Objective-C examples to the readme. Added a new example application in Objective-C that has the same minimalist feature set as the Swift example application, plus a little code to exercise round-tripping of coordinates for Path.

Fixes #17.

/cc @friedbunny @tmcw