### PR TITLE
Use UniChar type for marker letters

### DIFF
--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -125,9 +125,8 @@ public class Marker: NSObject, Point {
      */
     public convenience init(coordinate: CLLocationCoordinate2D,
                             size: Size = .Small,
-                            letter: String) {
-        assert(letter.characters.count == 1, "A marker can only fit one letter.")
-        self.init(coordinate: coordinate, size: size, label: .Letter(letter.characters.first!))
+                            letter: UniChar) {
+        self.init(coordinate: coordinate, size: size, label: .Letter(Character(UnicodeScalar(letter))))
     }
     
     /**


### PR DESCRIPTION
Both Swift and Objective-C understand `UniChar` and limit it to just one character.