### PR TITLE
Add standalone marker API method

### DIFF
--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -26,22 +26,32 @@ public protocol Point: Overlay {
 }
 
 /**
- A pin-shaped marker placed at a specific point on the map.
- 
- The Maki icon set is [open source](https://github.com/mapbox/maki/) and [dedicated to the public domain](https://creativecommons.org/publicdomain/zero/1.0/).
+ A pin-shaped marker image.
  */
-@objc(MBMarker)
-public class Marker: NSObject, Point {
+@objc(MBMarkerImage)
+public class MarkerImage: NSObject {
     /**
      The size of a marker.
      */
-    @objc(MBMarkerSize) public enum Size: Int {
+    @objc(MBMarkerSize)
+    public enum Size: Int, CustomStringConvertible {
         /// Small.
         case Small
         /// Medium.
         case Medium
         /// Large.
         case Large
+        
+        public var description: String {
+            switch self {
+            case .Small:
+                return "s"
+            case .Medium:
+                return "m"
+            case .Large:
+                return "l"
+            }
+        }
     }
     
     /// Something simple that can be placed atop a marker.
@@ -67,9 +77,6 @@ public class Marker: NSObject, Point {
             }
         }
     }
-    
-    /// The geographic coordinate to place the marker at.
-    public var coordinate: CLLocationCoordinate2D
     
     /**
      The size of the marker.
@@ -102,6 +109,26 @@ public class Marker: NSObject, Point {
     #endif
     
     /**
+     Initializes a red marker image with the given options.
+     
+     - parameter size: The size of the marker.
+     - parameter label: A label or Maki icon to place atop the pin.
+     */
+    internal init(size: Size, label: Label?) {
+        self.size = size
+        self.label = label
+    }
+}
+
+/**
+ A pin-shaped marker placed at a specific point on the map.
+ */
+@objc(MBMarker)
+public class Marker: MarkerImage, Point {
+    /// The geographic coordinate to place the marker at.
+    public var coordinate: CLLocationCoordinate2D
+    
+    /**
      Initializes a red marker with the given options.
      
      - parameter coordinate: The geographic coordinate to place the marker at.
@@ -110,10 +137,9 @@ public class Marker: NSObject, Point {
      */
     private init(coordinate: CLLocationCoordinate2D,
                  size: Size = .Small,
-                 label: Label? = nil) {
+                 label: Label?) {
         self.coordinate = coordinate
-        self.size = size
-        self.label = label
+        super.init(size: size, label: label)
     }
     
     /**
@@ -143,7 +169,9 @@ public class Marker: NSObject, Point {
     }
     
     /**
-     Initializes a red marker with a Maki icon.
+     Initializes a red marker with a [Maki](https://www.mapbox.com/maki-icons/) icon.
+     
+     The Maki icon set is [open source](https://github.com/mapbox/maki/) and [dedicated to the public domain](https://creativecommons.org/publicdomain/zero/1.0/).
      
      - parameter coordinate: The geographic coordinate to place the marker at.
      - parameter size: The size of the marker.
@@ -156,16 +184,6 @@ public class Marker: NSObject, Point {
     }
     
     public override var description: String {
-        let sizeComponent: String
-        switch size {
-        case .Small:
-            sizeComponent = "s"
-        case .Medium:
-            sizeComponent = "m"
-        case .Large:
-            sizeComponent = "l"
-        }
-        
         let labelComponent: String
         if let label = label {
             labelComponent = "-\(label)"
@@ -173,7 +191,7 @@ public class Marker: NSObject, Point {
             labelComponent = ""
         }
         
-        return "pin-\(sizeComponent)\(labelComponent)+\(color.toHexString())(\(coordinate.longitude),\(coordinate.latitude))"
+        return "pin-\(size)\(labelComponent)+\(color.toHexString())(\(coordinate.longitude),\(coordinate.latitude))"
     }
 }
 

--- a/MapboxStaticTests/MapboxStaticTests.swift
+++ b/MapboxStaticTests/MapboxStaticTests.swift
@@ -452,5 +452,31 @@ class MapboxStaticTests: XCTestCase {
 
         waitForExpectationsWithTimeout(1, handler: nil)
     }
-
+    
+    func testStandaloneMarker() {
+        let size = "m"
+        let label = "cafe"
+        let color = Color.brownColor()
+        let colorRaw = "996633"
+        
+        let markerExp = expectationWithDescription("builtin marker argument should format Maki request properly")
+        
+        let options = MarkerOptions(
+            size: .Medium,
+            iconName: "cafe")
+        options.color = color
+        
+        stub(isHost(serviceHost)) { request in
+            let scaleSuffix = options.scale == 1 ? "" : "@2x"
+            if let p = request.URL?.pathComponents where p[3] == "pin-\(size)-\(label)+\(colorRaw)\(scaleSuffix).png" {
+                markerExp.fulfill()
+            }
+            
+            return OHHTTPStubsResponse()
+        }
+        
+        Snapshot(options: options, accessToken: accessToken).image
+        
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
 }

--- a/OS X.playground/Contents.swift
+++ b/OS X.playground/Contents.swift
@@ -147,6 +147,20 @@ snapshot = Snapshot(
 snapshot.image
 
 /*:
+ ### Standalone markers
+ 
+ Use the `MarkerOptions` class to get a standalone marker image, which can be useful if you’re trying to composite it atop a map yourself.
+ */
+let markerOptions = MarkerOptions(
+    size: .Medium,
+    iconName: "cafe")
+markerOptions.color = .brownColor()
+snapshot = Snapshot(
+    options: markerOptions,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
  ### File format and quality
  
  When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).

--- a/OS X.playground/contents.xcplayground
+++ b/OS X.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered'>
+<playground version='5.0' target-platform='osx' display-mode='raw'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/README.md
+++ b/README.md
@@ -248,6 +248,34 @@ options.overlays = @[path, geojsonOverlay, markerOverlay, customMarker];
 
 ![](screenshots/autofit.png)
 
+#### Standalone markers
+ 
+Use the `MarkerOptions` class to get a standalone marker image, which can be useful if you’re trying to composite it atop a map yourself.
+
+```swift
+// main.swift
+let options = MarkerOptions(
+    size: .Medium,
+    iconName: "cafe")
+options.color = .brownColor()
+let snapshot = Snapshot(
+    options: options,
+    accessToken: "<#your access token#>")
+```
+
+```objc
+// main.m
+MBMarkerOptions *options = [[MBMarkerOptions alloc] initWithSize:MBMarkerSizeMedium
+                                                        iconName:@"cafe"];
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
+    options.color = [UIColor brownColor];
+#elif TARGET_OS_MAC
+    options.color = [NSColor brownColor];
+#endif
+MBSnapshot *snapshot = [[MBSnapshot alloc] initWithOptions:options
+                                               accessToken:@"<#your access token#>"];
+```
+
 #### File format and quality
 
 When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -147,6 +147,20 @@ snapshot = Snapshot(
 snapshot.image
 
 /*:
+ ### Standalone markers
+ 
+ Use the `MarkerOptions` class to get a standalone marker image, which can be useful if you’re trying to composite it atop a map yourself.
+ */
+let markerOptions = MarkerOptions(
+    size: .Medium,
+    iconName: "cafe")
+markerOptions.color = .brownColor()
+snapshot = Snapshot(
+    options: markerOptions,
+    accessToken: accessToken)
+snapshot.image
+
+/*:
  ### File format and quality
  
  When creating a map, you can also specify PNG or JPEG image format as well as various [bandwidth-saving image qualities](https://www.mapbox.com/api-documentation/#retrieve-a-static-map-image).

--- a/iOS.playground/contents.xcplayground
+++ b/iOS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='rendered'>
+<playground version='5.0' target-platform='ios' display-mode='raw'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/timeline.xctimeline
+++ b/iOS.playground/timeline.xctimeline
@@ -28,7 +28,7 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5029&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485046271.908407"
+         documentLocation = "#CharacterRangeLen=394&amp;CharacterRangeLoc=5029&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485079710.543464"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
@@ -54,6 +54,11 @@
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
          documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2898&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=485046272.334115"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5401&amp;EndingColumnNumber=15&amp;EndingLineNumber=160&amp;StartingColumnNumber=1&amp;StartingLineNumber=160&amp;Timestamp=485079710.648538"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
A new MarkerOptions class conforms to a common SnapshotOptionsProtocol and inherits from MarkerImage like Marker does. This class is responsible for configuring a request for a standalone marker from the classic Static API.