### PR TITLE
Pass through error message

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -24,6 +24,11 @@ class ViewController: UIViewController {
             zoomLevel: 6,
             size: imageView.bounds.size)
         Snapshot(options: options, accessToken: accessToken).image { [weak self] (image, error) in
+            guard error == nil else {
+                print(error)
+                return
+            }
+            
             self?.imageView.image = image
         }
 


### PR DESCRIPTION
Even after #32, API errors (as opposed to HTTP errors) would be dropped on the floor, leading to no image and no error. This change adopts what MapboxGeocoder.swift and MapboxDirections.swift do, additionally using the absence of a decodable image as an indicator of an error.