### PR TITLE
Update for Swift 3

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -5,9 +5,9 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        window = UIWindow(frame: UIScreen.mainScreen().bounds)
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]? = [:]) -> Bool {
+        window = UIWindow(frame: UIScreen.main().bounds)
         window!.rootViewController = ViewController()
         window!.makeKeyAndVisible()
         return true

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -22,6 +22,11 @@
 	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -11,19 +11,32 @@ class ViewController: UIViewController {
         super.viewDidLoad()
 
         imageView = UIImageView(frame: view.bounds)
-        imageView.backgroundColor = UIColor.blackColor()
+        imageView.backgroundColor = UIColor.black()
         view.addSubview(imageView)
     }
 
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         let options = SnapshotOptions(
             mapIdentifiers: ["justin.tm2-basemap"],
-            centerCoordinate: CLLocationCoordinate2D(latitude: 45, longitude: -122),
-            zoomLevel: 6,
+            centerCoordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
+            zoomLevel: 15,
             size: imageView.bounds.size)
-        Snapshot(options: options, accessToken: accessToken).image { [weak self] (image, error) in
+        
+        let url = URL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")
+        let customMarker = CustomMarker(
+            coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
+            url: url!)
+        
+        let geojsonOverlay: GeoJSON
+        let geojsonURL = NSURL(string: "http://git.io/vCv9U") as! URL
+        let gjs = try! NSString(contentsOf: geojsonURL, usedEncoding: nil)
+        geojsonOverlay = GeoJSON(objectString: gjs as String)
+        
+        options.overlays = [customMarker, geojsonOverlay]
+        
+        _ = Snapshot(options: options, accessToken: accessToken).image { [weak self] (image, error) in
             guard error == nil else {
                 print(error)
                 return

--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -558,11 +558,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					DA20FB9A1CE3DEBB00B07762 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA20FBB81CE4757E00B07762 = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -955,6 +956,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -975,6 +977,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1023,6 +1027,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1032,6 +1037,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2D526F1AE52AC93AE1C09017 /* Pods-MapboxStaticMacTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1048,6 +1054,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D5E31B6E6D896A65E0E407CB /* Pods-MapboxStaticMacTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1057,6 +1064,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -1099,6 +1107,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1130,6 +1139,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -1175,6 +1185,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1185,9 +1196,9 @@
 		DAF15A601CE90A6C0040E86C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.ObjC;
@@ -1198,9 +1209,9 @@
 		DAF15A611CE90A6C0040E86C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.ObjC;
@@ -1296,8 +1307,8 @@
 		DDAD196C1BD9B1780057AC9F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CURRENT_PROJECT_VERSION = 3;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
@@ -1309,12 +1320,13 @@
 		DDAD196D1BD9B1780057AC9F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CURRENT_PROJECT_VERSION = 3;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
 				PRODUCT_NAME = "MapboxStatic (Swift)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -1323,6 +1335,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 55948DDFD41BC7FD1F8FE960 /* Pods-MapboxStaticTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				INFOPLIST_FILE = MapboxStaticTests/Info.plist;
@@ -1337,12 +1350,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 98400B78B5201FF795872436 /* Pods-MapboxStaticTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				INFOPLIST_FILE = MapboxStaticTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic Mac.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic iOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic tvOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic watchOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic/Color.swift
+++ b/MapboxStatic/Color.swift
@@ -15,7 +15,7 @@ internal extension Color {
 
         let color: Color
         #if os(OSX)
-            color = colorUsingColorSpaceName(NSCalibratedRGBColorSpace)!
+            color = usingColorSpaceName(NSCalibratedRGBColorSpace)!
         #else
             color = self
         #endif
@@ -29,7 +29,7 @@ internal extension Color {
     }
 
     convenience init(hexString: String) {
-        var hexString = hexString.stringByReplacingOccurrencesOfString("#", withString: "")
+        var hexString = hexString.replacingOccurrences(of: "#", with: "")
 
         if hexString.characters.count == 3 {
             let digits = Array(hexString.characters)
@@ -40,10 +40,10 @@ internal extension Color {
         var g: CGFloat = 0
         var b: CGFloat = 0
         
-        if hexString.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == 6 {
+        if hexString.lengthOfBytes(using: String.Encoding.utf8) == 6 {
             var hexInt: UInt32 = 0
 
-            if NSScanner(string: hexString).scanHexInt(&hexInt) {
+            if Scanner(string: hexString).scanHexInt32(&hexInt) {
                 r = CGFloat((hexInt >> 16) & 0xff) / 255
                 g = CGFloat((hexInt >> 8) & 0xff) / 255
                 b = CGFloat(hexInt & 0xff) / 255

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -38,11 +38,11 @@ public class MarkerImage: NSObject {
      */
     @objc(MBMarkerSize)
     public enum Size: Int, CustomStringConvertible {
-        /// small.
+        /// Small.
         case small
-        /// medium.
+        /// Medium.
         case medium
-        /// large.
+        /// Large.
         case large
         
         public var description: String {

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -4,10 +4,13 @@
     import UIKit
 #endif
 
-let allowedCharacterSet: NSCharacterSet = {
-    let characterSet = NSCharacterSet.URLPathAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
-    characterSet.removeCharactersInString("/)")
-    return characterSet
+let allowedCharacterSet: CharacterSet = {
+    // this causes a runtime exception with Xcode 8 beta 1
+//    var allowedCharacters = CharacterSet.urlPathAllowed
+//    allowedCharacters.remove(charactersIn: "/)")
+//    return allowedCharacters
+    
+    return CharacterSet(charactersIn: "/)").inverted
 }()
 
 /**
@@ -35,20 +38,20 @@ public class MarkerImage: NSObject {
      */
     @objc(MBMarkerSize)
     public enum Size: Int, CustomStringConvertible {
-        /// Small.
-        case Small
-        /// Medium.
-        case Medium
-        /// Large.
-        case Large
+        /// small.
+        case small
+        /// medium.
+        case medium
+        /// large.
+        case large
         
         public var description: String {
             switch self {
-            case .Small:
+            case .small:
                 return "s"
-            case .Medium:
+            case .medium:
                 return "m"
-            case .Large:
+            case .large:
                 return "l"
             }
         }
@@ -57,22 +60,22 @@ public class MarkerImage: NSObject {
     /// Something simple that can be placed atop a marker.
     public enum Label: CustomStringConvertible {
         /// A lowercase English letter from A through Z. An uppercase letter is automatically converted to a lowercase letter.
-        case Letter(Character)
+        case letter(Character)
         /// A number from 0 through 99.
-        case Number(Int)
+        case number(Int)
         /// The name of a [Maki](https://www.mapbox.com/maki-icons/) icon.
-        case IconName(String)
+        case iconName(String)
         
         public var description: String {
             switch self {
-            case .Letter(let letter):
-                let lower = "\(letter)".lowercaseString
+            case .letter(let letter):
+                let lower = "\(letter)".lowercased()
                 assert(letter >= "a" && letter <= "z")
                 return lower
-            case .Number(let number):
+            case .number(let number):
                 assert(number >= 0 && number < 100)
                 return "\(number)"
-            case .IconName(let name):
+            case .iconName(let name):
                 return "\(name)"
             }
         }
@@ -98,14 +101,14 @@ public class MarkerImage: NSObject {
      
      By default, the marker is red.
      */
-    public var color: NSColor = .redColor()
+    public var color: NSColor = .red()
     #else
     /**
      The color of the pin part of the marker.
      
      By default, the marker is red.
      */
-    public var color: UIColor = .redColor()
+    public var color: UIColor = .red()
     #endif
     
     /**
@@ -136,7 +139,7 @@ public class Marker: MarkerImage, Point {
      - parameter label: A label or Maki icon to place atop the pin.
      */
     private init(coordinate: CLLocationCoordinate2D,
-                 size: Size = .Small,
+                 size: Size = .small,
                  label: Label?) {
         self.coordinate = coordinate
         super.init(size: size, label: label)
@@ -150,9 +153,9 @@ public class Marker: MarkerImage, Point {
      - parameter letter: An English letter from A through Z to place atop the pin.
      */
     public convenience init(coordinate: CLLocationCoordinate2D,
-                            size: Size = .Small,
+                            size: Size = .small,
                             letter: UniChar) {
-        self.init(coordinate: coordinate, size: size, label: .Letter(Character(UnicodeScalar(letter))))
+        self.init(coordinate: coordinate, size: size, label: .letter(Character(UnicodeScalar(letter))))
     }
     
     /**
@@ -163,9 +166,9 @@ public class Marker: MarkerImage, Point {
      - parameter number: A number from 0 through 99 to place atop the pin.
      */
     public convenience init(coordinate: CLLocationCoordinate2D,
-                            size: Size = .Small,
+                            size: Size = .small,
                             number: Int) {
-        self.init(coordinate: coordinate, size: size, label: .Number(number))
+        self.init(coordinate: coordinate, size: size, label: .number(number))
     }
     
     /**
@@ -178,9 +181,9 @@ public class Marker: MarkerImage, Point {
      - parameter iconName: The name of a [Maki](https://www.mapbox.com/maki-icons/) icon to place atop the pin.
      */
     public convenience init(coordinate: CLLocationCoordinate2D,
-                            size: Size = .Small,
+                            size: Size = .small,
                             iconName: String) {
-        self.init(coordinate: coordinate, size: size, label: .IconName(iconName))
+        self.init(coordinate: coordinate, size: size, label: .iconName(iconName))
     }
     
     public override var description: String {
@@ -210,7 +213,7 @@ public class CustomMarker: NSObject, Overlay {
      
      The API caches custom marker images according to the `Expires` and `Cache-Control` headers. If you host the image on your own server, make sure that at least one of these headers is set to an proper value to prevent repeated requests for the image.
      */
-    public var URL: NSURL
+    public var url: URL
     
     /**
      Initializes a marker with the given coordinate and image URL.
@@ -218,14 +221,14 @@ public class CustomMarker: NSObject, Overlay {
      - parameter coordinate: The geographic coordinate to place the marker at.
      - parameter URL: The HTTP or HTTPS URL of the image.
      */
-    public init(coordinate: CLLocationCoordinate2D, URL: NSURL) {
+    public init(coordinate: CLLocationCoordinate2D, url: URL) {
         self.coordinate = coordinate
-        self.URL = URL
+        self.url = url
     }
     
     public override var description: String {
-        let escapedURL = URL.absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
-        return "url-\(escapedURL)(\(coordinate.longitude),\(coordinate.latitude))"
+        let escapedURL = url.absoluteString?.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)!
+        return "url-\(escapedURL!)(\(coordinate.longitude),\(coordinate.latitude))"
     }
 }
 
@@ -239,8 +242,17 @@ public class GeoJSON: NSObject, Overlay {
     /// String representation of the GeoJSON object to display.
     public var objectString: String
     
+    var pm: String? {
+        get {
+            return self.pm
+        }
+        set(newValue) {
+            self.pm = newValue
+        }
+    }
+    
     public override var description: String {
-        let escapedObjectString = objectString.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        let escapedObjectString = objectString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed)!
         return "geojson(\(escapedObjectString))"
     }
     
@@ -252,10 +264,10 @@ public class GeoJSON: NSObject, Overlay {
      */
     public init?(object: [String: AnyObject]) {
         // This should be a throwing initializer rather than a failiable initializer, but inheriting from Objective-C triggers a warning: no calls to throwing functions occur within 'try' expression
-        guard let data = try? NSJSONSerialization.dataWithJSONObject(object, options: []) else {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: []) else {
             return nil
         }
-        objectString = String(data: data, encoding: NSUTF8StringEncoding)!
+        objectString = String(data: data, encoding: String.Encoding.utf8)!
     }
     
     /**
@@ -358,7 +370,7 @@ public class Path: NSObject, Overlay {
     public init(coordinates: UnsafePointer<CLLocationCoordinate2D>, count: UInt) {
         var convertedCoordinates: [CLLocationCoordinate2D] = []
         for i in 0..<count {
-            convertedCoordinates.append(coordinates.advancedBy(Int(i)).memory)
+            convertedCoordinates.append(coordinates.advanced(by: Int(i)).pointee)            
         }
         self.coordinates = convertedCoordinates
     }
@@ -381,16 +393,16 @@ public class Path: NSObject, Overlay {
      
      - note: This initializer is intended for Objective-C usage. In Swift code, use the `coordinates` property.
      */
-    public func getCoordinates(coordinates: UnsafeMutablePointer<CLLocationCoordinate2D>) {
+    public func getCoordinates(_ coordinates: UnsafeMutablePointer<CLLocationCoordinate2D>) {
         for i in 0..<self.coordinates.count {
-            coordinates.advancedBy(i).memory = self.coordinates[i]
+            coordinates.advanced(by: i).pointee = self.coordinates[i]
         }
     }
     
     // based on https://github.com/mapbox/polyline
-    private func polylineEncode(coordinates: [CLLocationCoordinate2D]) -> String {
+    private func polylineEncode(_ coordinates: [CLLocationCoordinate2D]) -> String {
 
-        func encodeCoordinate(let coordinate: CLLocationDegrees) -> String {
+        func encodeCoordinate(_ coordinate: CLLocationDegrees) -> String {
 
             var c = Int(round(coordinate * 1e5))
 
@@ -425,7 +437,7 @@ public class Path: NSObject, Overlay {
     }
     
     public override var description: String {
-        let encodedPolyline = polylineEncode(coordinates).stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        let encodedPolyline = polylineEncode(coordinates).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed)!
         return "path-\(strokeWidth)+\(strokeColor.toHexString())-\(strokeOpacity)+\(fillColor.toHexString())-\(fillOpacity)(\(encodedPolyline))"
     }
 }

--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -12,18 +12,18 @@ typealias JSONDictionary = [String: AnyObject]
 public let MBStaticErrorDomain = "MBStaticErrorDomain"
 
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
-let defaultAccessToken = NSBundle.mainBundle().objectForInfoDictionaryKey("MGLMapboxAccessToken") as? String
+let defaultAccessToken = Bundle.main().objectForInfoDictionaryKey("MGLMapboxAccessToken") as? String
 
 /// The user agent string for any HTTP requests performed directly within this library.
 let userAgent: String = {
     var components: [String] = []
     
-    if let appName = NSBundle.mainBundle().infoDictionary?["CFBundleName"] as? String ?? NSBundle.mainBundle().infoDictionary?["CFBundleIdentifier"] as? String {
-        let version = NSBundle.mainBundle().infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    if let appName = Bundle.main().infoDictionary?["CFBundleName"] as? String ?? Bundle.main().infoDictionary?["CFBundleIdentifier"] as? String {
+        let version = Bundle.main().infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         components.append("\(appName)/\(version)")
     }
     
-    let libraryBundle: NSBundle? = NSBundle(forClass: Snapshot.self)
+    let libraryBundle: Bundle? = Bundle(for: Snapshot.self)
     
     if let libraryName = libraryBundle?.infoDictionary?["CFBundleName"] as? String, version = libraryBundle?.infoDictionary?["CFBundleShortVersionString"] as? String {
         components.append("\(libraryName)/\(version)")
@@ -41,7 +41,7 @@ let userAgent: String = {
     #elseif os(Linux)
         system = "Linux"
     #endif
-    let systemVersion = NSProcessInfo().operatingSystemVersion
+    let systemVersion = ProcessInfo().operatingSystemVersion
     components.append("\(system)/\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)")
     
     let chip: String
@@ -56,13 +56,13 @@ let userAgent: String = {
     #endif
     components.append("(\(chip))")
     
-    return components.joinWithSeparator(" ")
+    return components.joined(separator: " ")
 }()
 
 @objc(MBSnapshotOptionsProtocol)
 public protocol SnapshotOptionsProtocol: NSObjectProtocol {
     var path: String { get }
-    var params: [NSURLQueryItem] { get }
+    var params: [URLQueryItem] { get }
 }
 
 /**
@@ -76,23 +76,23 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
     @objc(MBSnapshotFormat)
     public enum Format: Int {
         /// True-color Portable Network Graphics format.
-        case PNG
+        case png
         /// 32-color color-indexed Portable Network Graphics format.
-        case PNG32
+        case png32
         /// 64-color color-indexed Portable Network Graphics format.
-        case PNG64
+        case png64
         /// 128-color color-indexed Portable Network Graphics format.
-        case PNG128
+        case png128
         /// 256-color color-indexed Portable Network Graphics format.
-        case PNG256
+        case png256
         /// JPEG format at default quality.
-        case JPEG
+        case jpeg
         /// JPEG format at 70% quality.
-        case JPEG70
+        case jpeg70
         /// JPEG format at 80% quality.
-        case JPEG80
+        case jpeg80
         /// JPEG format at 90% quality.
-        case JPEG90
+        case jpeg90
     }
     
     // MARK: Configuring the Map Data
@@ -136,7 +136,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      
      The default value of this property is `SnapshotOptions.Format.PNG`, causing the image to be output in true-color Portable Network Graphics format.
      */
-    public var format: Format = .PNG
+    public var format: Format = .png
     
     /**
      The logical size of the image to output, measured in points.
@@ -151,7 +151,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the main screen. However, only images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = NSScreen.mainScreen()?.backingScaleFactor ?? 1
+    public var scale: CGFloat = NSScreen.main()?.backingScaleFactor ?? 1
     #elseif os(watchOS)
     /**
      The scale factor of the image.
@@ -160,7 +160,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the screen. Images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = WKInterfaceDevice.currentDevice().screenScale
+    public var scale: CGFloat = WKInterfaceDevice.current().screenScale
     #else
     /**
      The scale factor of the image.
@@ -169,7 +169,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the main screen. However, only images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = UIScreen.mainScreen().scale
+    public var scale: CGFloat = UIScreen.main().scale
     #endif
     
     /**
@@ -207,7 +207,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      */
     public var path: String {
         assert(!mapIdentifiers.isEmpty, "At least one map identifier must be specified.")
-        let tileSetComponent = mapIdentifiers.joinWithSeparator(",")
+        let tileSetComponent = mapIdentifiers.joined(separator: ",")
         
         let position: String
         if let centerCoordinate = centerCoordinate {
@@ -230,28 +230,28 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
         if overlays.isEmpty {
             overlaysComponent = ""
         } else {
-            overlaysComponent = "/" + overlays.map { return "\($0)" }.joinWithSeparator(",")
+            overlaysComponent = "/" + overlays.map { return "\($0)" }.joined(separator: ",")
         }
         
         let formatComponent: String
         switch format {
-        case .PNG:
+        case .png:
             formatComponent = "png"
-        case .PNG32:
+        case .png32:
             formatComponent = "png32"
-        case .PNG64:
+        case .png64:
             formatComponent = "png64"
-        case .PNG128:
+        case .png128:
             formatComponent = "png128"
-        case .PNG256:
+        case .png256:
             formatComponent = "png256"
-        case .JPEG:
+        case .jpeg:
             formatComponent = "jpg"
-        case .JPEG70:
+        case .jpeg70:
             formatComponent = "jpg70"
-        case .JPEG80:
+        case .jpeg80:
             formatComponent = "jpg80"
-        case .JPEG90:
+        case .jpeg90:
             formatComponent = "jpg90"
         }
         
@@ -263,7 +263,7 @@ public class SnapshotOptions: NSObject, SnapshotOptionsProtocol {
      
      - returns: The query URL component as an array of name/value pairs.
      */
-    public var params: [NSURLQueryItem] {
+    public var params: [URLQueryItem] {
         return []
     }
 }
@@ -281,7 +281,7 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the main screen. However, only images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = NSScreen.mainScreen()?.backingScaleFactor ?? 1
+    public var scale: CGFloat = NSScreen.main()?.backingScaleFactor ?? 1
     #elseif os(watchOS)
     /**
      The scale factor of the image.
@@ -290,7 +290,7 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the screen. Images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = WKInterfaceDevice.currentDevice().screenScale
+    public var scale: CGFloat = WKInterfaceDevice.current().screenScale
     #else
     /**
      The scale factor of the image.
@@ -299,7 +299,7 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      
      The default value of this property matches the natural scale factor associated with the main screen. However, only images with a scale factor of 1.0 or 2.0 are ever returned by the classic Static API, so a scale factor of 1.0 of less results in a 1× (standard-resolution) image, while a scale factor greater than 1.0 results in a 2× (high-resolution or Retina) image.
      */
-    public var scale: CGFloat = UIScreen.mainScreen().scale
+    public var scale: CGFloat = UIScreen.main().scale
     #endif
     
     /**
@@ -318,8 +318,8 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      - parameter size: The size of the marker.
      - parameter letter: An English letter from A through Z to place atop the pin.
      */
-    public convenience init(size: Size = .Small, letter: UniChar) {
-        self.init(size: size, label: .Letter(Character(UnicodeScalar(letter))))
+    public convenience init(size: Size = .small, letter: UniChar) {
+        self.init(size: size, label: .letter(Character(UnicodeScalar(letter))))
     }
     
     /**
@@ -328,8 +328,8 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      - parameter size: The size of the marker.
      - parameter number: A number from 0 through 99 to place atop the pin.
      */
-    public convenience init(size: Size = .Small, number: Int) {
-        self.init(size: size, label: .Number(number))
+    public convenience init(size: Size = .small, number: Int) {
+        self.init(size: size, label: .number(number))
     }
     
     /**
@@ -338,8 +338,8 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      - parameter size: The size of the marker.
      - parameter iconName: The name of a [Maki](https://www.mapbox.com/maki-icons/) icon to place atop the pin.
      */
-    public convenience init(size: Size = .Small, iconName: String) {
-        self.init(size: size, label: .IconName(iconName))
+    public convenience init(size: Size = .small, iconName: String) {
+        self.init(size: size, label: .iconName(iconName))
     }
     
     /**
@@ -363,7 +363,7 @@ public class MarkerOptions: MarkerImage, SnapshotOptionsProtocol {
      
      - returns: The query URL component as an array of name/value pairs.
      */
-    public var params: [NSURLQueryItem] {
+    public var params: [URLQueryItem] {
         return []
     }
 }
@@ -414,7 +414,7 @@ public class Snapshot: NSObject {
         self.options = options
         self.accessToken = accessToken!
         
-        let baseURLComponents = NSURLComponents()
+        var baseURLComponents = URLComponents()
         baseURLComponents.scheme = "https"
         baseURLComponents.host = host ?? "api.mapbox.com"
         self.apiEndpoint = baseURLComponents.string!
@@ -446,10 +446,10 @@ public class Snapshot: NSObject {
     /**
      The HTTP URL used to fetch the snapshot image from the API.
      */
-    public var URL: NSURL {
-        let components = NSURLComponents()
+    public var url: URL {
+        var components = URLComponents()
         components.queryItems = params
-        return NSURL(string: "\(apiEndpoint)\(options.path)?\(components.percentEncodedQuery!)")!
+        return URL(string: "\(apiEndpoint)\(options.path)?\(components.percentEncodedQuery!)")!
     }
     
     /**
@@ -457,9 +457,9 @@ public class Snapshot: NSObject {
      
      - returns: The query URL component as an array of name/value pairs.
      */
-    private var params: [NSURLQueryItem] {
+    private var params: [URLQueryItem] {
         return options.params + [
-            NSURLQueryItem(name: "access_token", value: accessToken),
+            URLQueryItem(name: "access_token", value: accessToken),
         ]
     }
     
@@ -469,7 +469,7 @@ public class Snapshot: NSObject {
      - attention: This property’s getter retrieves the image synchronously over a network connection, blocking the thread on which it is called. If a connection error or server error occurs, the getter returns `nil`. Consider using the asynchronous `image(completionHandler:)` method instead to avoid blocking the calling thread and to get more details about any error that may occur.
      */
     public var image: Image? {
-        if let data = NSData(contentsOfURL: URL) {
+        if let data = try? Data(contentsOf: url) {
             return Image(data: data)
         } else {
             return nil
@@ -486,15 +486,15 @@ public class Snapshot: NSObject {
      - parameter completionHandler: The closure (block) to call with the resulting image. This closure is executed on the application’s main thread.
      - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting image, cancel this task.
      */
-    public func image(completionHandler handler: CompletionHandler) -> NSURLSessionDataTask {
-        let request = NSMutableURLRequest(URL: URL)
+    public func image(completionHandler handler: CompletionHandler) -> URLSessionDataTask {
+        let request = NSMutableURLRequest(url: url)
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-        let task = NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) in
+        let task = URLSession.shared().dataTask(with: request as URLRequest) { (data, response, error) in
             var json: JSONDictionary = [:]
             var image: Image?
             if let data = data {
                 do {
-                    json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? JSONDictionary ?? json
+                    json = try JSONSerialization.jsonObject(with: data, options: []) as? JSONDictionary ?? json
                 } catch {
                     image = Image(data: data)
                 }
@@ -503,13 +503,13 @@ public class Snapshot: NSObject {
             let apiMessage = json["message"] as? String
             guard image != nil && error == nil && apiMessage == nil else {
                 let apiError = Snapshot.descriptiveError(json, response: response, underlyingError: error)
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     handler(image: nil, error: apiError)
                 }
                 return
             }
             
-            dispatch_async(dispatch_get_main_queue()) {
+            DispatchQueue.main.async {
                 handler(image: image, error: nil)
             }
         }
@@ -520,29 +520,29 @@ public class Snapshot: NSObject {
     /**
      Returns an error that supplements the given underlying error with additional information from the an HTTP response’s body or headers.
      */
-    private static func descriptiveError(json: JSONDictionary, response: NSURLResponse?, underlyingError error: NSError?) -> NSError {
+    private static func descriptiveError(_ json: JSONDictionary, response: URLResponse?, underlyingError error: NSError?) -> NSError {
         var userInfo = error?.userInfo ?? [:]
-        if let response = response as? NSHTTPURLResponse {
+        if let response = response as? HTTPURLResponse {
             var failureReason: String? = nil
             var recoverySuggestion: String? = nil
             switch response.statusCode {
             case 429:
-                if let timeInterval = response.allHeaderFields["x-rate-limit-interval"] as? NSTimeInterval, maximumCountOfRequests = response.allHeaderFields["x-rate-limit-limit"] as? UInt {
-                    let intervalFormatter = NSDateComponentsFormatter()
-                    intervalFormatter.unitsStyle = .Full
-                    let formattedInterval = intervalFormatter.stringFromTimeInterval(timeInterval)
-                    let formattedCount = NSNumberFormatter.localizedStringFromNumber(maximumCountOfRequests, numberStyle: .DecimalStyle)
+                if let timeInterval = response.allHeaderFields["x-rate-limit-interval"] as? TimeInterval, maximumCountOfRequests = response.allHeaderFields["x-rate-limit-limit"] as? UInt {
+                    let intervalFormatter = DateComponentsFormatter()
+                    intervalFormatter.unitsStyle = .full
+                    let formattedInterval = intervalFormatter.string(from: timeInterval)
+                    let formattedCount = NumberFormatter.localizedString(from: maximumCountOfRequests, number: .decimal)
                     failureReason = "More than \(formattedCount) requests have been made with this access token within a period of \(formattedInterval)."
                 }
                 if let rolloverTimestamp = response.allHeaderFields["x-rate-limit-reset"] as? Double {
-                    let date = NSDate(timeIntervalSince1970: rolloverTimestamp)
-                    let formattedDate = NSDateFormatter.localizedStringFromDate(date, dateStyle: .LongStyle, timeStyle: .FullStyle)
+                    let date = Date(timeIntervalSince1970: rolloverTimestamp)
+                    let formattedDate = DateFormatter.localizedString(from: date, dateStyle: .longStyle, timeStyle: .fullStyle)
                     recoverySuggestion = "Wait until \(formattedDate) before retrying."
                 }
             default:
                 failureReason = json["message"] as? String
             }
-            userInfo[NSLocalizedFailureReasonErrorKey] = failureReason ?? userInfo[NSLocalizedFailureReasonErrorKey] ?? NSHTTPURLResponse.localizedStringForStatusCode(error?.code ?? -1)
+            userInfo[NSLocalizedFailureReasonErrorKey] = failureReason ?? userInfo[NSLocalizedFailureReasonErrorKey] ?? HTTPURLResponse.localizedString(forStatusCode: error?.code ?? -1)
             userInfo[NSLocalizedRecoverySuggestionErrorKey] = recoverySuggestion ?? userInfo[NSLocalizedRecoverySuggestionErrorKey]
         }
         userInfo[NSUnderlyingErrorKey] = error

--- a/OS X.playground/Contents.swift
+++ b/OS X.playground/Contents.swift
@@ -50,7 +50,7 @@ snapshot.image { (image, error) in
 /*:
  If you’re using your own HTTP library or routines, you can also retrieve a snapshot’s `URL` property.
  */
-snapshot.URL
+snapshot.url
 
 /*:
  ## Overlays
@@ -63,21 +63,22 @@ snapshot.URL
  */
 let markerOverlay = Marker(
     coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
-    size: .Medium,
+    size: .medium,
     iconName: "cafe")
-markerOverlay.color = .brownColor()
+markerOverlay.color = .brown()
 options.overlays = [markerOverlay]
 snapshot = Snapshot(
     options: options,
     accessToken: accessToken)
 snapshot.image
+print(snapshot)
 
 /*:
  ### Custom marker
  */
 let customMarker = CustomMarker(
     coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
-    URL: NSURL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!)
+    url: URL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!)
 options.overlays = [customMarker]
 snapshot = Snapshot(
     options: options,
@@ -89,9 +90,9 @@ snapshot.image
  */
 let geojsonOverlay: GeoJSON
 do {
-    let geojsonURL = NSURL(string: "http://git.io/vCv9U")!
-    let geojsonString = try NSString(contentsOfURL: geojsonURL, encoding: NSUTF8StringEncoding)
-    geojsonOverlay = GeoJSON(string: geojsonString as String)
+    let geojsonURL = URL(string: "http://git.io/vCv9U")!
+    let geojsonString = try NSString(contentsOf: geojsonURL, encoding: 4) as String
+    geojsonOverlay = GeoJSON(objectString: geojsonString)
 }
 options.overlays = [geojsonOverlay]
 snapshot = Snapshot(
@@ -103,7 +104,7 @@ snapshot.image
  ### Path
  */
 let path = Path(
-    pathCoordinates: [
+    coordinates: [
         CLLocationCoordinate2D(
             latitude: 45.52475063103141,
             longitude: -122.68209457397461),
@@ -124,8 +125,8 @@ let path = Path(
             longitude: -122.68209457397461),
     ])
 path.strokeWidth = 2
-path.strokeColor = .blackColor()
-path.fillColor = .redColor()
+path.strokeColor = .black()
+path.fillColor = .red()
 path.fillOpacity = 0.25
 options.overlays = [path]
 snapshot = Snapshot(
@@ -152,9 +153,9 @@ snapshot.image
  Use the `MarkerOptions` class to get a standalone marker image, which can be useful if you’re trying to composite it atop a map yourself.
  */
 let markerOptions = MarkerOptions(
-    size: .Medium,
+    size: .medium,
     iconName: "cafe")
-markerOptions.color = .brownColor()
+markerOptions.color = .brown()
 snapshot = Snapshot(
     options: markerOptions,
     accessToken: accessToken)

--- a/OS X.playground/contents.xcplayground
+++ b/OS X.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw'>
+<playground version='5.0' target-platform='osx' display-mode='raw' executeOnSourceChanges='false'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -50,7 +50,7 @@ snapshot.image { (image, error) in
 /*:
  If you’re using your own HTTP library or routines, you can also retrieve a snapshot’s `URL` property.
  */
-snapshot.URL
+snapshot.url
 
 /*:
  ## Overlays
@@ -63,9 +63,9 @@ snapshot.URL
  */
 let markerOverlay = Marker(
     coordinate: CLLocationCoordinate2D(latitude: 45.52, longitude: -122.681944),
-    size: .Medium,
+    size: .medium,
     iconName: "cafe")
-markerOverlay.color = .brownColor()
+markerOverlay.color = .brown()
 options.overlays = [markerOverlay]
 snapshot = Snapshot(
     options: options,
@@ -75,9 +75,10 @@ snapshot.image
 /*:
  ### Custom marker
  */
+let url = URL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")
 let customMarker = CustomMarker(
     coordinate: CLLocationCoordinate2D(latitude: 45.522, longitude: -122.69),
-    URL: NSURL(string: "https://www.mapbox.com/help/img/screenshots/rocket.png")!)
+    url: url!)
 options.overlays = [customMarker]
 snapshot = Snapshot(
     options: options,
@@ -89,9 +90,10 @@ snapshot.image
  */
 let geojsonOverlay: GeoJSON
 do {
-    let geojsonURL = NSURL(string: "http://git.io/vCv9U")!
-    let geojsonString = try NSString(contentsOfURL: geojsonURL, encoding: NSUTF8StringEncoding)
+    let geojsonURL = NSURL(string: "http://git.io/vCv9U") as! URL
+    let geojsonString = try! NSString(contentsOf: geojsonURL, usedEncoding: nil)
     geojsonOverlay = GeoJSON(objectString: geojsonString as String)
+    
 }
 options.overlays = [geojsonOverlay]
 snapshot = Snapshot(
@@ -102,8 +104,7 @@ snapshot.image
 /*:
  ### Path
  */
-let path = Path(
-    coordinates: [
+let path = Path(coordinates: [
         CLLocationCoordinate2D(
             latitude: 45.52475063103141,
             longitude: -122.68209457397461),
@@ -124,8 +125,8 @@ let path = Path(
             longitude: -122.68209457397461),
     ])
 path.strokeWidth = 2
-path.strokeColor = .blackColor()
-path.fillColor = .redColor()
+path.strokeColor = .black()
+path.fillColor = .red()
 path.fillOpacity = 0.25
 options.overlays = [path]
 snapshot = Snapshot(
@@ -152,9 +153,9 @@ snapshot.image
  Use the `MarkerOptions` class to get a standalone marker image, which can be useful if you’re trying to composite it atop a map yourself.
  */
 let markerOptions = MarkerOptions(
-    size: .Medium,
+    size: .medium,
     iconName: "cafe")
-markerOptions.color = .brownColor()
+markerOptions.color = .brown()
 snapshot = Snapshot(
     options: markerOptions,
     accessToken: accessToken)

--- a/iOS.playground/contents.xcplayground
+++ b/iOS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='raw'>
+<playground version='5.0' target-platform='ios' display-mode='raw' last-migration='0800'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/iOS.playground/timeline.xctimeline
+++ b/iOS.playground/timeline.xctimeline
@@ -3,62 +3,67 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=1835&amp;EndingColumnNumber=15&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=484939570.791401"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=488226311.010094"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2906&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=485046245.490493"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=488226311.010325"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3250&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=485046245.490617"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=488235240.11765"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3654&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=485046245.490745"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=488245807.644939"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4646&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=485046271.908279"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=488245807.645055"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=394&amp;CharacterRangeLoc=5029&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485079710.543464"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=147&amp;StartingColumnNumber=1&amp;StartingLineNumber=143&amp;Timestamp=488245807.645167"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=4638&amp;EndingColumnNumber=15&amp;EndingLineNumber=133&amp;StartingColumnNumber=1&amp;StartingLineNumber=133&amp;Timestamp=485046272.334115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=134&amp;StartingColumnNumber=1&amp;StartingLineNumber=134&amp;Timestamp=488245807.645278"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5021&amp;EndingColumnNumber=15&amp;EndingLineNumber=146&amp;StartingColumnNumber=1&amp;StartingLineNumber=146&amp;Timestamp=485046272.334115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=147&amp;StartingColumnNumber=1&amp;StartingLineNumber=143&amp;Timestamp=488245807.645389"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3646&amp;EndingColumnNumber=15&amp;EndingLineNumber=99&amp;StartingColumnNumber=1&amp;StartingLineNumber=99&amp;Timestamp=485046272.334115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=101&amp;StartingColumnNumber=1&amp;StartingLineNumber=101&amp;Timestamp=488245807.645499"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=3242&amp;EndingColumnNumber=15&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=485046272.334115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=488235240.118479"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2898&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=485046272.334115"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=72&amp;StartingColumnNumber=1&amp;StartingLineNumber=72&amp;Timestamp=488226311.011369"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=5401&amp;EndingColumnNumber=15&amp;EndingLineNumber=160&amp;StartingColumnNumber=1&amp;StartingLineNumber=160&amp;Timestamp=485079710.648538"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=0&amp;EndingColumnNumber=15&amp;EndingLineNumber=161&amp;StartingColumnNumber=1&amp;StartingLineNumber=161&amp;Timestamp=488245807.645914"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/boundsj/workspace/MapboxStatic.swift/iOS.playground#CharacterRangeLen=221&amp;CharacterRangeLoc=3303&amp;EndingLineNumber=91&amp;StartingLineNumber=91&amp;Timestamp=488245875.83512"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
This ports the Swift 2.2 implementation to Swift 3. It is a work in progress and there are several known issues but it is functional and can be used, for now, to help test applications written with the Xcode 8 and Swift 3 betas that use MapboxStatic.

#### Todo:

- [x]  Syntax update to Swift 3 in library, example apps, and playgrounds
- [ ]  Use [Swift 3 version of OHHTTPStubs ](https://github.com/AliSoftware/OHHTTPStubs/pull/182)
- [ ] Consider wrapping changes in `#if swift(>=3.0)` blocks to help maintain backwards compatibility with Swift 2.2+

#### Known issues:

- Tests won't run because the HTTP mock library is not updated, yet
- The most obvious port of `allowedCharacterSet` in Overlay.swift seems to cause an exception in the
first Xcode 8 beta. This needs more investigation. For now, the workaround is to use an inverted 
`CharacterSet` for `MBCustomMarker` and `CharacterSet.urlPathAllowed` for `GeoJSON` and `Path` overlays.