### PR TITLE
OS X → macOS

### DIFF
--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -31,7 +31,7 @@ let userAgent: String = {
     
     let system: String
     #if os(OSX)
-        system = "OS X"
+        system = "macOS"
     #elseif os(iOS)
         system = "iOS"
     #elseif os(watchOS)


### PR DESCRIPTION
For consistency with the Mapbox macOS SDK, the user agent string now says “macOS” instead of “OS X” on the Mac.

/ref mapbox/MapboxGeocoder.swift#58 mapbox/MapboxDirections.swift#55
/cc @mick