### PR TITLE
Migrate to Swift 2.3

### DIFF
--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -418,12 +418,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA20FBCD1CE4757E00B07762 /* Build configuration list for PBXNativeTarget "MapboxStaticMacTests" */;
 			buildPhases = (
-				092C294824CDB97A7E2F4D6E /* 📦 Check Pods Manifest.lock */,
+				092C294824CDB97A7E2F4D6E /* [CP] Check Pods Manifest.lock */,
 				DA20FBBE1CE4757E00B07762 /* Sources */,
 				DA20FBBF1CE4757E00B07762 /* Frameworks */,
 				DA20FBC01CE4757E00B07762 /* Resources */,
-				28B8BC44A6CCECDD33AFFE36 /* 📦 Embed Pods Frameworks */,
-				5B04146AC0344CD06C823C12 /* 📦 Copy Pods Resources */,
+				28B8BC44A6CCECDD33AFFE36 /* [CP] Embed Pods Frameworks */,
+				5B04146AC0344CD06C823C12 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -457,12 +457,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA4B4BA81CE8F83100296A52 /* Build configuration list for PBXNativeTarget "MapboxStaticTVTests" */;
 			buildPhases = (
-				9FC29FEA9F93FAAD284BED52 /* 📦 Check Pods Manifest.lock */,
+				9FC29FEA9F93FAAD284BED52 /* [CP] Check Pods Manifest.lock */,
 				DA4B4B971CE8F83100296A52 /* Sources */,
 				DA4B4B981CE8F83100296A52 /* Frameworks */,
 				DA4B4B991CE8F83100296A52 /* Resources */,
-				6A24C788ECC9CA4CF2C3499C /* 📦 Embed Pods Frameworks */,
-				0DF94B20C9D38DDF27C604F5 /* 📦 Copy Pods Resources */,
+				6A24C788ECC9CA4CF2C3499C /* [CP] Embed Pods Frameworks */,
+				0DF94B20C9D38DDF27C604F5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -534,12 +534,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DDAD197F1BD9B24F0057AC9F /* Build configuration list for PBXNativeTarget "MapboxStaticTests" */;
 			buildPhases = (
-				7891F32DF0BAD0AC1F534333 /* 📦 Check Pods Manifest.lock */,
+				7891F32DF0BAD0AC1F534333 /* [CP] Check Pods Manifest.lock */,
 				DDAD19741BD9B24F0057AC9F /* Sources */,
 				DDAD19751BD9B24F0057AC9F /* Frameworks */,
 				DDAD19761BD9B24F0057AC9F /* Resources */,
-				E1E1F20B0DD4EE819A964FA0 /* 📦 Embed Pods Frameworks */,
-				70C81ECB8E2F3F87998A235E /* 📦 Copy Pods Resources */,
+				E1E1F20B0DD4EE819A964FA0 /* [CP] Embed Pods Frameworks */,
+				70C81ECB8E2F3F87998A235E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -563,30 +563,38 @@
 				TargetAttributes = {
 					DA20FB9A1CE3DEBB00B07762 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA20FBB81CE4757E00B07762 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA20FBC11CE4757E00B07762 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA4B4B911CE8F83100296A52 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA4B4B9A1CE8F83100296A52 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DAF15A3A1CE8FB8D0040E86C = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DAF15A4A1CE90A6C0040E86C = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
 					DDAD19581BD9B1780057AC9F = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					DDAD19771BD9B24F0057AC9F = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -688,29 +696,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		092C294824CDB97A7E2F4D6E /* 📦 Check Pods Manifest.lock */ = {
+		092C294824CDB97A7E2F4D6E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		0DF94B20C9D38DDF27C604F5 /* 📦 Copy Pods Resources */ = {
+		0DF94B20C9D38DDF27C604F5 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -718,14 +726,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticTVTests/Pods-MapboxStaticTVTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		28B8BC44A6CCECDD33AFFE36 /* 📦 Embed Pods Frameworks */ = {
+		28B8BC44A6CCECDD33AFFE36 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -733,14 +741,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5B04146AC0344CD06C823C12 /* 📦 Copy Pods Resources */ = {
+		5B04146AC0344CD06C823C12 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -748,14 +756,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticMacTests/Pods-MapboxStaticMacTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6A24C788ECC9CA4CF2C3499C /* 📦 Embed Pods Frameworks */ = {
+		6A24C788ECC9CA4CF2C3499C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -763,14 +771,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticTVTests/Pods-MapboxStaticTVTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		70C81ECB8E2F3F87998A235E /* 📦 Copy Pods Resources */ = {
+		70C81ECB8E2F3F87998A235E /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -778,44 +786,44 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxStaticTests/Pods-MapboxStaticTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7891F32DF0BAD0AC1F534333 /* 📦 Check Pods Manifest.lock */ = {
+		7891F32DF0BAD0AC1F534333 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		9FC29FEA9F93FAAD284BED52 /* 📦 Check Pods Manifest.lock */ = {
+		9FC29FEA9F93FAAD284BED52 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		E1E1F20B0DD4EE819A964FA0 /* 📦 Embed Pods Frameworks */ = {
+		E1E1F20B0DD4EE819A964FA0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -955,6 +963,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -975,6 +984,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -999,6 +1009,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1023,6 +1034,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1041,6 +1053,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1057,6 +1070,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -1076,6 +1090,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1099,6 +1114,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1116,6 +1132,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -1130,6 +1147,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticTests;
 				PRODUCT_NAME = MapboxStaticTests;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -1151,6 +1169,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1175,6 +1194,7 @@
 				PRODUCT_NAME = MapboxStatic;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1302,6 +1322,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
 				PRODUCT_NAME = "MapboxStatic (Swift)";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1315,6 +1336,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxStaticExample.Swift;
 				PRODUCT_NAME = "MapboxStatic (Swift)";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -1330,6 +1352,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1343,6 +1366,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.StaticTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -224,7 +224,7 @@ public class CustomMarker: NSObject, Overlay {
     }
     
     public override var description: String {
-        let escapedURL = URL.absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        let escapedURL = URL.absoluteString!.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
         return "url-\(escapedURL)(\(coordinate.longitude),\(coordinate.latitude))"
     }
 }

--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -224,7 +224,11 @@ public class CustomMarker: NSObject, Overlay {
     }
     
     public override var description: String {
-        let escapedURL = URL.absoluteString!.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        #if swift(>=2.3)
+            let escapedURL = URL.absoluteString!.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        #else
+            let escapedURL = URL.absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
+        #endif
         return "url-\(escapedURL)(\(coordinate.longitude),\(coordinate.latitude))"
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ use_frameworks!
 #end
 
 def shared_test_pods
-  pod 'OHHTTPStubs/Swift', '~> 5.0.0', :configurations => ['Debug']
+  pod 'OHHTTPStubs/Swift', :git => 'https://github.com/AliSoftware/OHHTTPStubs.git', :commit => '4995ecd762abdd81227d14faf65fde003fbbe789', :configurations => ['Debug']
 end
 
 target 'MapboxStaticTests' do

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ To run the included unit tests, you need to use [CocoaPods](http://cocoapods.org
 1. `open MapboxStatic.xcworkspace`
 1. `Command+U` or `xcodebuild test`
 
+The workspace requires CocoaPods 1.1.0.beta.1 or greater if opening inside Xcode 8.
+
 ### More info
 
 This repository includes an example iOS application written in Swift, as well as Swift playgrounds for iOS and macOS. (Open the playgrounds inside of MapboxStatic.xcworkspace.) More examples are available in the [Mapbox API Documentation](https://www.mapbox.com/api-documentation/?language=Swift#static-classic).


### PR DESCRIPTION
This required a newer-than-5.1.0 version of OHHTTPStubs for AliSoftware/OHHTTPStubs#184 as well as CocoaPods 1.1.0.beta.1 for CocoaPods/CocoaPods#5540.

/cc @boundsj @bsudekum