### PR TITLE
Don’t even try to deserialize non-JSON response data

### DIFF
--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -493,9 +493,13 @@ public class Snapshot: NSObject {
             var json: JSONDictionary = [:]
             var image: Image?
             if let data = data {
-                do {
-                    json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? JSONDictionary ?? json
-                } catch {
+                if response?.MIMEType == "application/json" {
+                    do {
+                        json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as? JSONDictionary ?? json
+                    } catch {
+                        assert(false, "Invalid data")
+                    }
+                } else {
                     image = Image(data: data)
                 }
             }


### PR DESCRIPTION
For consistency with mapbox/MapboxDirections.swift#72 and mapbox/MapboxGeocoder.swift#71, don’t attempt to deserialize non-JSON response data. In the case of this library, the error would’ve been caught by the _expected_ fallback of initializing an image out of the data. But it’s quite bizarre for the “good” code path to be inside an error handler. So now this library is additionally capable of tripping an assertion if the response claims to be JSON but isn’t well-formed for some reason.

/cc @willwhite