### PR TITLE
Fix Swift 3.1 compatibility

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "AliSoftware/OHHTTPStubs" "swift-3.0"
+github "AliSoftware/OHHTTPStubs" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "AliSoftware/OHHTTPStubs" "57feceaabf333e72b2c637dfba6c13a7a5c49619"
+github "AliSoftware/OHHTTPStubs" "8660a5a2253bdd6291be36251ba90b06bceb46a2"

--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -201,7 +201,7 @@ open class Snapshot: NSObject {
             
             let apiMessage = json["message"] as? String
             guard image != nil && error == nil && apiMessage == nil else {
-                let apiError = Snapshot.descriptiveError(json, response: response, underlyingError: error as? NSError)
+                let apiError = Snapshot.descriptiveError(json, response: response, underlyingError: error as NSError?)
                 DispatchQueue.main.async {
                     handler(nil, apiError)
                 }


### PR DESCRIPTION
Resolved some Swift 3.1 compiler warnings in unit test code. Some optionals should’ve been force-unwrapped because they’d only be used if the optional turned out to be `nil`.

Also updated dependencies.

/cc @bsudekum