### PR TITLE
Only add fill to path if it has opacity

### DIFF
--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -437,6 +437,11 @@ open class Path: NSObject, Overlay {
     
     open override var description: String {
         let encodedPolyline = polylineEncode(coordinates).addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)!
-        return "path-\(strokeWidth)+\(strokeColor.toHexString())-\(strokeOpacity)+\(fillColor.toHexString())-\(fillOpacity)(\(encodedPolyline))"
+        var description = "path-\(strokeWidth)+\(strokeColor.toHexString())-\(strokeOpacity)"
+        if fillOpacity > 0 {
+            description += "+\(fillColor.toHexString())-\(fillOpacity)"
+        }
+        description += "(\(encodedPolyline))"
+        return description
     }
 }


### PR DESCRIPTION
The Static API treats a path as a closed polygon as long as fill options are provided. `Path.description` should omit the fill options if the fill would be transparent.

Fixes #57.

/cc @arturpk @bsudekum @frederoni