### PR TITLE
Remove vestigal references to fillOpacity

### DIFF
--- a/MapboxStatic/Overlay.swift
+++ b/MapboxStatic/Overlay.swift
@@ -333,7 +333,7 @@ open class Path: NSObject, Overlay {
      
      The polyline is 1 point wide and stroked with Davy’s gray (33% white).
      
-     To turn the overlay into a polygon, close the path by ensuring that the first and last coordinates are the same. To fill the polygon, set the `fillOpacity` property to a value greater than 0.0.
+     To turn the overlay into a polygon, close the path by ensuring that the first and last coordinates are the same. To fill the polygon, set the `fillColor` property to a color whose alpha component is greater than 0.0.
      
      - parameter coordinates: An array of geographic coordinates defining the path of the overlay.
      */
@@ -346,7 +346,7 @@ open class Path: NSObject, Overlay {
      
      The polyline is 1 point wide and stroked with Davy’s gray (33% white).
      
-     To turn the overlay into a polygon, close the path by ensuring that the first and last coordinates are the same. To fill the polygon, set the `fillOpacity` property to a value greater than 0.0.
+     To turn the overlay into a polygon, close the path by ensuring that the first and last coordinates are the same. To fill the polygon, set the `fillColor` property to a color whose alpha component is greater than 0.0.
      
      - parameter coordinates: An array of geographic coordinates defining the path of the overlay.
      

--- a/iOS.playground/Contents.swift
+++ b/iOS.playground/Contents.swift
@@ -146,8 +146,7 @@ let path = Path(
     ])
 path.strokeWidth = 2
 path.strokeColor = .black
-path.fillColor = .red
-path.fillOpacity = 0.25
+path.fillColor = UIColor.red.withAlphaComponent(0.25)
 options.overlays = [path]
 snapshot = Snapshot(
     options: options,

--- a/macOS.playground/Contents.swift
+++ b/macOS.playground/Contents.swift
@@ -146,8 +146,7 @@ let path = Path(
     ])
 path.strokeWidth = 2
 path.strokeColor = .black
-path.fillColor = .red
-path.fillOpacity = 0.25
+path.fillColor = NSColor.red.withAlphaComponent(0.25)
 options.overlays = [path]
 snapshot = Snapshot(
     options: options,


### PR DESCRIPTION
Removed references to the `Path.fillOpacity` property, which was removed in #61 in favor of reading the alpha component out of `fillColor`.

/cc @frederoni @friedbunny