### PR TITLE
Prevent dynamic dispatch from being used

### DIFF
--- a/MapboxStatic/Color.swift
+++ b/MapboxStatic/Color.swift
@@ -7,7 +7,7 @@
 #endif
 
 internal extension Color {
-    internal func toHexString() -> String {
+    @nonobjc func toHexString() -> String {
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0


### PR DESCRIPTION
Fixes #65 
Swift or Obj-C applications extending UIColor or NSColor like:
```swift
extension UIColor {
    func toHexString() -> String {
        return "#000000"
    }
}
```
would override the internal `toHexString()` which excludes the # and would cause a corrupt URL.
This method gets overridden because the class inherits from NSObject and therefore makes use of dynamic dispatching.

Note that Swift 4.0 in unaffected by this bug/feature.

@1ec5 👀 