### PR TITLE
Specify Swift version in podspec

### DIFF
--- a/MapboxStatic.swift.podspec
+++ b/MapboxStatic.swift.podspec
@@ -41,6 +41,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxStatic"
+  s.swift_version = "3.0"
 
   s.dependency "Polyline", "~> 4.2"
 


### PR DESCRIPTION
CocoaPods 1.4.0 supports a [`swift_version` setting in podspecs](https://blog.cocoapods.org/CocoaPods-1.4.0/#swift-version-dsl), so this adds that.

CocoaPods also says that the `.swift-version` file is being deprecated, but they’re not the only consumers of this file, so let's leave it around for the time being.

/cc @1ec5