### PR TITLE
Add support for Apple Watch Gen 4.

### DIFF
--- a/MapboxStatic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MapboxStatic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MapboxStatic/Snapshot.swift
+++ b/MapboxStatic/Snapshot.swift
@@ -53,6 +53,10 @@ let userAgent: String = {
         chip = "arm64"
     #elseif arch(i386)
         chip = "i386"
+    #elseif os(watchOS) // Workaround for incorrect arch in machine.h for simulator ⌚️ gen 4
+        chip = "i386"
+    #else
+        chip = "unknown"
     #endif
     components.append("(\(chip))")
     


### PR DESCRIPTION
Fixes a similar issue occurring in MapboxGeocoder.swift where the compilation derivative doesn't catch the i386 architecture if you are compiling for the watchOS simulator.
/cc @1ec5 @friedbunny 