### PR TITLE
Fix compiler warnings and dev support for Xcode 10.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "AliSoftware/OHHTTPStubs" ~> 6.0
+github "AliSoftware/OHHTTPStubs" ~> 7.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "AliSoftware/OHHTTPStubs" "6.1.0"
+github "AliSoftware/OHHTTPStubs" "7.0.0"
 github "raphaelmor/Polyline" "v4.2.0"

--- a/MapboxStatic.xcodeproj/project.pbxproj
+++ b/MapboxStatic.xcodeproj/project.pbxproj
@@ -713,7 +713,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					DA20FB9A1CE3DEBB00B07762 = {
@@ -755,7 +755,7 @@
 			};
 			buildConfigurationList = DDAD19541BD9B1780057AC9F /* Build configuration list for PBXProject "MapboxStatic" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -1440,6 +1440,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1498,6 +1499,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic Mac.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic iOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic tvOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic watchOS.xcscheme
+++ b/MapboxStatic.xcodeproj/xcshareddata/xcschemes/MapboxStatic watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxStatic/Color.swift
+++ b/MapboxStatic/Color.swift
@@ -6,7 +6,7 @@
     typealias Color = UIColor
 #endif
 
-internal extension Color {
+extension Color {
     @nonobjc func toHexString() -> String {
         var r: CGFloat = 0
         var g: CGFloat = 0


### PR DESCRIPTION
Fixes #90 - Warning about redundant modifier in Xcode 10.2

- Bumped OHHTTPStubs so that it builds with Xcode 10.2
- Fixed a compiler warning about redundant modifier. Minimized scope to future proof.

cc @1ec5 